### PR TITLE
implement overrides retriever (closes #10)

### DIFF
--- a/lib/autoproj/daemon/github/pull_request.rb
+++ b/lib/autoproj/daemon/github/pull_request.rb
@@ -73,6 +73,11 @@ module Autoproj
                     Time.parse(@model['updated_at'])
                 end
 
+                # @return [String]
+                def body
+                    @model['body']
+                end
+
                 def ==(other)
                     model == other.model
                 end

--- a/lib/autoproj/daemon/overrides_retriever.rb
+++ b/lib/autoproj/daemon/overrides_retriever.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'autoproj/daemon/github/client'
+require 'autoproj/daemon/github/pull_request'
+require 'octokit'
+
+module Autoproj
+    module Daemon
+        # A class that retrievers overrides from a pull request
+        class OverridesRetriever
+            DEPENDS_ON_RX = /(?:.*depends?(?:\s+on)?\s*\:?\s*\n)(.*)/mi.freeze
+            OPEN_TASK_RX = %r{(?:-\s*\[\s*\]\s*)([A-Za-z\d+_\-\:\/\#\.]+)}.freeze
+
+            PULL_REQUEST_URL_RX = %r{https?\:\/\/(?:\w+\.)?github.com(?:\/+)
+                ([A-Za-z\d+_\-]+)(?:\/+)([A-Za-z\d+_\-]+)(?:\/+)pull(?:\/+)(\d+)}x.freeze
+
+            OWNER_NAME_AND_NUMBER_RX = %r{([A-Za-z\d+_\-]+)\/
+                ([A-Za-z\d+_\-]+)\#(\d+)}x.freeze
+
+            NUMBER_RX = /\#(\d+)/.freeze
+
+            # @return [Github::Client]
+            attr_reader :client
+
+            # @param [Github::Client] client
+            def initialize(client)
+                @client = client
+            end
+
+            # @param [String] body
+            # @return [Array<String>]
+            def parse_task_list(body)
+                return [] unless (m = DEPENDS_ON_RX.match(body))
+
+                lines = m[1].each_line.map do |l|
+                    l.strip!
+                    l unless l.empty?
+                end.compact
+
+                valid = []
+                lines.each do |l|
+                    break unless l =~ /^-/
+
+                    valid << l
+                end
+
+                valid.join("\n").scan(OPEN_TASK_RX).flatten
+            end
+
+            # @param [String] task
+            # @param [Github::PullRequest] pull_request
+            # @return [Github::PullRequest, nil]
+            def task_to_pull_request(task, pull_request)
+                if (match = PULL_REQUEST_URL_RX.match(task))
+                    owner, name, number = match[1..-1]
+                elsif (match = OWNER_NAME_AND_NUMBER_RX.match(task))
+                    owner, name, number = match[1..-1]
+                elsif (match = NUMBER_RX.match(task))
+                    owner = pull_request.base_owner
+                    name = pull_request.base_name
+                    number = match[1]
+                else
+                    return nil
+                end
+
+                number = number.to_i
+                client.pull_requests(owner, name).find { |pr| pr.number == number }
+            rescue Octokit::NotFound
+                nil
+            end
+
+            # @param [Array<Github::PullRequest] visited
+            # @param [Github::PullRequest] pull_request
+            # @return [Boolean]
+            def visited?(visited, pull_request)
+                visited.any? do |pr|
+                    pr.base_owner == pull_request.base_owner &&
+                        pr.base_name == pull_request.base_name &&
+                        pr.number == pull_request.number
+                end
+            end
+
+            # @param [Github::PullRequest] pull_request
+            # @return [Array<Github::PullRequest>]
+            def retrieve_dependencies(pull_request, visited = [], deps = [])
+                visited << pull_request
+                dependencies = parse_task_list(pull_request.body).map do |task|
+                    task_to_pull_request(task, pull_request)
+                end.compact
+
+                dependencies.each do |pr|
+                    next if visited?(visited, pr)
+
+                    deps << pr
+                    retrieve_dependencies(pr, visited, deps)
+                end
+                deps
+            end
+        end
+    end
+end

--- a/test/autoproj/daemon/github/test_pull_request.rb
+++ b/test/autoproj/daemon/github/test_pull_request.rb
@@ -71,6 +71,12 @@ module Autoproj
                 it 'returns the head repo name' do
                     assert_equal 'vscode', pull_request.head_name
                 end
+
+                it 'returns the pull request body' do
+                    assert_equal 'Faced the same issue #80837 '\
+                        "and didn't see much activity.\r\nThis PR fixes #80837 ",
+                                 pull_request.body
+                end
             end
         end
     end

--- a/test/autoproj/daemon/test_overrides_retriever.rb
+++ b/test/autoproj/daemon/test_overrides_retriever.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'autoproj/daemon/overrides_retriever'
+require 'octokit'
+
+module Autoproj
+    # Main daemon module
+    module Daemon
+        describe OverridesRetriever do # rubocop: disable Metrics/BlockLength
+            # @return [Autoproj::Daemon::OverridesRetriever]
+            attr_reader :retriever
+
+            # @return [FlexMock]
+            attr_reader :client
+
+            before do
+                @client = flexmock
+                @retriever = OverridesRetriever.new(client)
+                @pull_requests = {}
+                client.should_receive(:pull_requests)
+                      .with(any, any)
+                      .and_return do |owner, name|
+                          @pull_requests["#{owner}/#{name}"] || []
+                      end
+            end
+
+            def add_pull_request(owner, name, number, body, state: 'open')
+                pr = create_pull_request(
+                    base_owner: owner,
+                    base_name: name,
+                    body: body,
+                    number: number,
+                    state: state
+                )
+                @pull_requests["#{owner}/#{name}"] ||= []
+                @pull_requests["#{owner}/#{name}"] << pr
+                pr
+            end
+
+            describe 'PULL_REQUEST_URL_RX' do
+                it 'parses owner, name and number from PR url' do
+                    owner, name, number = OverridesRetriever::PULL_REQUEST_URL_RX.match(
+                        'https://github.com////g-arjones//demo_pkg//pull//122'
+                    )[1..-1]
+
+                    assert_equal 'g-arjones', owner
+                    assert_equal 'demo_pkg', name
+                    assert_equal '122', number
+                end
+            end
+
+            describe 'OWNER_NAME_AND_NUMBER_RX' do
+                it 'parses owner, name and number from PR path' do
+                    owner, name, number =
+                        OverridesRetriever::OWNER_NAME_AND_NUMBER_RX.match(
+                            'g-arjones/demo_pkg#122'
+                        )[1..-1]
+
+                    assert_equal 'g-arjones', owner
+                    assert_equal 'demo_pkg', name
+                    assert_equal '122', number
+                end
+            end
+            describe 'NUMBER_RX' do
+                it 'parses the PR number from relative PR path' do
+                    number =
+                        OverridesRetriever::NUMBER_RX.match(
+                            '#122'
+                        )[1]
+
+                    assert_equal '122', number
+                end
+            end
+            describe '#parse_task_list' do # rubocop: disable Metrics/BlockLength
+                it 'parses the list of pending tasks' do
+                    body = <<~EOFBODY
+                        Depends on:
+
+                        - [ ] one
+                        - [ ] two
+                        - [x] three
+                        - [ ] four
+                    EOFBODY
+
+                    tasks = []
+                    tasks << 'one'
+                    tasks << 'two'
+                    tasks << 'four'
+
+                    assert_equal tasks, retriever.parse_task_list(body)
+                end
+                it 'only parses the first list' do
+                    body = <<~EOFBODY
+                        Depends on:
+                        - [ ] one
+
+                        List of something else, not dependencies:
+                        - [ ] two
+                    EOFBODY
+
+                    tasks = []
+                    tasks << 'one'
+                    assert_equal tasks, retriever.parse_task_list(body)
+                end
+                it 'allows multilevel task lists' do
+                    body = <<~EOFBODY
+                        Depends on:
+                        - 1. Feature 1:
+                          - [ ] one
+                          - [ ] two
+
+                        - [ ] Feature 2:
+                          - [x] three
+                          - [ ] four
+                    EOFBODY
+
+                    tasks = []
+                    tasks << 'one'
+                    tasks << 'two'
+                    tasks << 'Feature'
+                    tasks << 'four'
+                    assert_equal tasks, retriever.parse_task_list(body)
+                end
+            end
+            describe '#task_to_pull_request' do # rubocop: disable Metrics/BlockLength
+                it 'returns a pull request when given a url' do
+                    pr = add_pull_request('g-arjones', 'demo_pkg', 22, '')
+                    assert_equal pr, retriever.task_to_pull_request(
+                        'https://github.com/g-arjones/demo_pkg/pull/22', pr
+                    )
+                end
+                it 'returns a pull request when given a full path' do
+                    pr = add_pull_request('g-arjones', 'demo_pkg', 22, '')
+                    assert_equal pr, retriever.task_to_pull_request(
+                        'g-arjones/demo_pkg#22', pr
+                    )
+                end
+                it 'returns a pull request when given a relative path' do
+                    pr = add_pull_request('g-arjones', 'demo_pkg', 22, '')
+                    assert_equal pr, retriever.task_to_pull_request(
+                        '#22', pr
+                    )
+                end
+                it 'returns nil when the task item does not look like a PR reference' do
+                    assert_nil retriever.task_to_pull_request(
+                        'Feature', nil
+                    )
+                end
+                it 'returns nil if the PR cannot be found' do
+                    assert_nil retriever.task_to_pull_request(
+                        'https://github.com/g-arjones/demo_pkg/pull/22', nil
+                    )
+                end
+                it 'returns nil if the github resource does not exist' do
+                    @client = flexmock
+                    @retriever = OverridesRetriever.new(client)
+
+                    client.should_receive(:pull_requests)
+                          .with(any, any).and_raise(Octokit::NotFound)
+
+                    assert_nil retriever.task_to_pull_request(
+                        'https://github.com/g-arjones/demo_pkg/pull/22', nil
+                    )
+                end
+            end
+            # rubocop: disable Metrics/BlockLength
+            describe '#retrieve_dependencies' do
+                it 'recursively fetches pull request dependencies' do
+                    body_driver_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] tidewise/drivers-orogen-gps_ublox#22
+                    EOFBODY
+                    pr_drivers_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-gps_ublox',
+                        11, body_driver_gps_ublox
+                    )
+
+                    body_driver_orogen_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] rock-core/drivers-orogen-iodrivers_base#33
+                        - [ ] rock-core/base-cmake#44
+                    EOFBODY
+                    pr_driver_orogen_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-orogen-gps_ublox',
+                        22, body_driver_orogen_gps_ublox
+                    )
+
+                    pr_driver_orogen_iodrivers_base = add_pull_request(
+                        'rock-core', 'drivers-orogen-iodrivers_base',
+                        33, nil
+                    )
+                    pr_base_cmake = add_pull_request(
+                        'rock-core', 'base-cmake',
+                        44, nil
+                    )
+
+                    depends = retriever.retrieve_dependencies(pr_drivers_gps_ublox)
+                    assert_equal [pr_driver_orogen_gps_ublox,
+                                  pr_driver_orogen_iodrivers_base,
+                                  pr_base_cmake], depends
+                end
+                it 'breaks cyclic dependencies' do
+                    body_driver_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] tidewise/drivers-orogen-gps_ublox#22
+                    EOFBODY
+                    pr_drivers_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-gps_ublox',
+                        11, body_driver_gps_ublox
+                    )
+
+                    body_driver_orogen_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] tidewise/drivers-gps_ublox#11
+                    EOFBODY
+                    pr_driver_orogen_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-orogen-gps_ublox',
+                        22, body_driver_orogen_gps_ublox
+                    )
+
+                    depends = retriever.retrieve_dependencies(pr_drivers_gps_ublox)
+                    assert_equal [pr_driver_orogen_gps_ublox], depends
+                end
+                it 'does not add same PR twice' do
+                    body_driver_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] tidewise/drivers-orogen-gps_ublox#22
+                        - [ ] rock-core/base-cmake#44
+                    EOFBODY
+                    pr_drivers_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-gps_ublox',
+                        11, body_driver_gps_ublox
+                    )
+
+                    body_driver_orogen_gps_ublox = <<~EOFBODY
+                        Depends on:
+                        - [ ] rock-core/base-cmake#44
+                    EOFBODY
+                    pr_driver_orogen_gps_ublox = add_pull_request(
+                        'tidewise', 'drivers-orogen-gps_ublox',
+                        22, body_driver_orogen_gps_ublox
+                    )
+
+                    pr_base_cmake = add_pull_request(
+                        'rock-core', 'base-cmake',
+                        44, nil
+                    )
+
+                    depends = retriever.retrieve_dependencies(pr_drivers_gps_ublox)
+                    assert_equal [pr_driver_orogen_gps_ublox,
+                                  pr_base_cmake], depends
+                end
+            end
+            # rubocop: enable Metrics/BlockLength
+        end
+    end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ def create_pull_request(options)
         number: options[:number],
         title: options[:title],
         updated_at: options[:updated_at] || Time.now,
+        body: options[:body],
         base: {
             ref: options[:base_branch],
             sha: options[:base_sha],


### PR DESCRIPTION
Works pretty nicely..

I wanted to implement just using regex with lookbehind to get the task items but didn't manage so I loop thorough all lines past the "Depends on" anchor until I find a line that does not look like a task item. It also allows to have nested lists and mixing things that are not pull requests in the task list.