### PR TITLE
ignore events on third-party repos

### DIFF
--- a/lib/autoproj/daemon/github_watcher.rb
+++ b/lib/autoproj/daemon/github_watcher.rb
@@ -151,12 +151,16 @@ module Autoproj
                                             pull_request: pull_request)
             end
 
+            # @param [String] owner The owner of the events feed
             # @param [Array] events An array of events
             # @return [void]
-            def handle_owner_events(events)
+            def handle_owner_events(owner, events)
                 events = filter_events(events)
                 push_events, pull_request_events =
                     events.partition { |event| event.kind_of? Github::PushEvent }
+
+                push_events.select! { |e| e.owner == owner }
+                pull_request_events.select! { |e| e.pull_request.base_owner == owner }
 
                 handle_push_events(push_events)
                 handle_pull_request_events(pull_request_events)
@@ -225,6 +229,7 @@ module Autoproj
                 loop do
                     owners.each do |owner|
                         handle_owner_events(
+                            owner,
                             client.fetch_events(
                                 owner, organization: organization?(owner)
                             )

--- a/test/autoproj/daemon/test_github_watcher.rb
+++ b/test/autoproj/daemon/test_github_watcher.rb
@@ -511,7 +511,35 @@ module Autoproj
                         .should_receive(:handle_pull_request_events)
                         .with(@events[2..3]).once
 
-                    watcher.handle_owner_events(@events)
+                    watcher.handle_owner_events('rock-core', @events)
+                end
+                it 'ignores events on third-party repos' do
+                    @events << create_push_event(
+                        owner: 'rock-core',
+                        name: 'drivers-gps_ublox',
+                        branch: 'master',
+                        created_at: Time.utc(2019, 'sep', 22, 23, 53, 35)
+                    )
+                    @events << create_pull_request_event(
+                        base_owner: 'rock-core',
+                        base_name: 'drivers-gps_ublox',
+                        base_branch: 'master',
+                        state: 'open',
+                        created_at: Time.utc(2019, 'sep', 22, 23, 53, 35)
+                    )
+
+                    add_package('drivers/gps_ublox', 'rock-core', 'drivers-gps_ublox')
+                    @cache.add(@events[1].pull_request, [])
+
+                    flexmock(watcher)
+                        .should_receive(:handle_push_events)
+                        .with([]).once
+
+                    flexmock(watcher)
+                        .should_receive(:handle_pull_request_events)
+                        .with([]).once
+
+                    watcher.handle_owner_events('tidewise', @events)
                 end
                 # rubocop: enable Metrics/BlockLength
             end


### PR DESCRIPTION
So... This took a while to track down but the issue was that events show up in the feed of both the organization/user that owns the repository and of the user that performed the action that triggered the event. Since we are using packages from @doudou 's personal account in our mainline, we are also polling his user events and these were clashing with events from organizations he works on and that also have packages in our mainline.