### PR TITLE
refactor entire test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/test_*.rb"]
+  t.warning = false
 end
 
 task :default => :test

--- a/lib/autoproj/cli/daemon.rb
+++ b/lib/autoproj/cli/daemon.rb
@@ -172,10 +172,10 @@ module Autoproj
                                                  buildconf_package.name, branch_name)
                     cache.delete(pull_request)
 
-                # rubocop: disable Lint/HandleExceptions
+                # rubocop: disable Lint/SuppressedException
                 rescue Octokit::UnprocessableEntity
                 end
-                # rubocop: enable Lint/HandleExceptions
+                # rubocop: enable Lint/SuppressedException
 
                 cache.dump
             end
@@ -264,10 +264,8 @@ module Autoproj
                 )
             end
 
-            # Starts watching the whole workspace
-            #
             # @return [void]
-            def start
+            def prepare
                 unless ws.config.daemon_api_key
                     raise Autoproj::ConfigError, 'you must configure the '\
                         'daemon before starting'
@@ -291,6 +289,13 @@ module Autoproj
                 )
 
                 setup_hooks
+            end
+
+            # Starts watching the whole workspace
+            #
+            # @return [void]
+            def start
+                prepare
                 buildconf_manager.synchronize_branches unless update_failed?
                 watcher.watch
             end

--- a/lib/autoproj/daemon/github/branch.rb
+++ b/lib/autoproj/daemon/github/branch.rb
@@ -13,6 +13,9 @@ module Autoproj
                 # @return [String]
                 attr_reader :name
 
+                # @return [Hash]
+                attr_reader :model
+
                 def initialize(owner, name, model)
                     @owner = owner
                     @name = name
@@ -27,6 +30,11 @@ module Autoproj
                 # @return [String]
                 def sha
                     @model['commit']['sha']
+                end
+
+                # @return [Boolean]
+                def ==(other)
+                    model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github/pull_request_event.rb
+++ b/lib/autoproj/daemon/github/pull_request_event.rb
@@ -8,6 +8,9 @@ module Autoproj
         module Github
             # A PullRequestEvent model representation
             class PullRequestEvent
+                # @return [Hash]
+                attr_reader :model
+
                 def initialize(model)
                     @model = JSON.parse(model.to_json)
                 end

--- a/lib/autoproj/daemon/github/push_event.rb
+++ b/lib/autoproj/daemon/github/push_event.rb
@@ -7,6 +7,9 @@ module Autoproj
         module Github
             # A PushEvent model representation
             class PushEvent
+                # @return [Hash]
+                attr_reader :model
+
                 def initialize(model)
                     @model = JSON.parse(model.to_json)
                 end

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'test_helper'
 require 'autoproj/daemon/buildbot'
 
 # Autoproj's main module
@@ -9,6 +10,8 @@ module Autoproj
         describe Buildbot do # rubocop: disable Metrics/BlockLength
             attr_reader :bb
             attr_reader :ws
+
+            include Autoproj::Daemon::TestHelpers
             before do
                 @ws = ws_create
                 @bb = Buildbot.new(ws)
@@ -103,7 +106,7 @@ module Autoproj
                         revision: 'abcdef'
                     ).once
 
-                    pr = create_pull_request(
+                    pr = autoproj_daemon_add_pull_request(
                         base_owner: 'tidewise',
                         base_name: 'drivers-gps_ublox',
                         number: 22,
@@ -126,7 +129,7 @@ module Autoproj
                         revision: 'abcdef'
                     ).once
 
-                    event = create_push_event(
+                    event = autoproj_daemon_add_push_event(
                         owner: 'tidewise',
                         name: 'drivers-gps_ublox',
                         branch: 'feature',

--- a/test/autoproj/daemon/test_package_repository.rb
+++ b/test/autoproj/daemon/test_package_repository.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'autoproj/daemon/package_repository'
+require 'test_helper'
 
 # Autoproj's main module
 module Autoproj
     # Daemon main module
     module Daemon
-        describe PackageRepository do # rubocop: disable Metrics/BlockLength
+        describe PackageRepository do
             attr_reader :package
             attr_reader :ws
             before do
@@ -16,7 +17,8 @@ module Autoproj
                     'rock-drivers',
                     'drivers-iodrivers_base',
                     { type: 'none' },
-                    ws: ws)
+                    ws: ws
+                )
             end
 
             describe '#autobuild' do

--- a/test/autoproj/daemon/test_pull_request_cache.rb
+++ b/test/autoproj/daemon/test_pull_request_cache.rb
@@ -8,6 +8,8 @@ module Autoproj
     module Daemon
         # rubocop: disable Metrics/BlockLength
         describe PullRequestCache::CachedPullRequest do
+            include Autoproj::Daemon::TestHelpers
+
             before do
                 @ws = ws_create
                 @cached = PullRequestCache::CachedPullRequest.new(
@@ -21,35 +23,35 @@ module Autoproj
 
             describe '#caches_pull_request?' do # rubocop: disable Metrics/BlockLength
                 it 'returns true if cached entry and PR are the same' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'pkg',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'pkg',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     assert @cached.caches_pull_request?(pr)
                 end
                 it 'returns false if base owners are different' do
-                    pr = create_pull_request(base_owner: 'rock-drivers',
-                                             base_name: 'pkg',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-drivers',
+                                                             base_name: 'pkg',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     refute @cached.caches_pull_request?(pr)
                 end
                 it 'returns false if base names are different' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     refute @cached.caches_pull_request?(pr)
                 end
                 it 'returns false if numbers are different' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'pkg',
-                                             number: 2,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'pkg',
+                                                             number: 2,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     refute @cached.caches_pull_request?(pr)
                 end
             end
@@ -57,17 +59,19 @@ module Autoproj
         # rubocop: enable Metrics/BlockLength
 
         describe PullRequestCache do # rubocop: disable Metrics/BlockLength
+            include Autoproj::Daemon::TestHelpers
+
             before do
                 @ws = ws_create
                 @cache = PullRequestCache.new(ws)
             end
             describe '#add' do # rubocop: disable Metrics/BlockLength
                 it 'adds a pull request to the cache' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
                     assert_equal 1, @cache.pull_requests.size
 
@@ -81,18 +85,18 @@ module Autoproj
                                  cached.overrides
                 end
                 it 'updates an existing entry' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
 
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'ghijkl')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'ghijkl')
 
                     @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
                     assert_equal 1, @cache.pull_requests.size
@@ -104,27 +108,27 @@ module Autoproj
 
             describe '#cached' do
                 it 'returns the cached PR' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     cached = @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
                     assert_equal cached, @cache.cached(pr)
                 end
                 it 'returns nil if PR is not cached' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     assert_nil @cache.cached(pr)
                 end
             end
 
             describe '#dump' do
                 it 'creates a cache file with all PRs' do
-                    pr = create_pull_request(
+                    pr = autoproj_daemon_create_pull_request(
                         base_owner: 'rock-core',
                         base_name: 'foobar',
                         number: 1,
@@ -141,38 +145,38 @@ module Autoproj
 
             describe '#changed?' do # rubocop: disable Metrics/BlockLength
                 it 'returns true if PR is not cached' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     assert @cache.changed?(
                         pr, ['pkg' => { 'remote_branch' => 'develop' }]
                     )
                 end
                 it 'returns true if PR changed' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'ghijkl',
-                                             updated_at: Time.now + 2)
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'ghijkl',
+                                                             updated_at: Time.now + 2)
                     assert @cache.changed?(
                         pr, ['pkg' => { 'remote_branch' => 'develop' }]
                     )
                 end
                 it 'returns false if PR did not change' do
-                    pr = create_pull_request(base_owner: 'rock-core',
-                                             base_name: 'foobar',
-                                             number: 1,
-                                             base_branch: 'master',
-                                             head_sha: 'abcdef')
+                    pr = autoproj_daemon_create_pull_request(base_owner: 'rock-core',
+                                                             base_name: 'foobar',
+                                                             number: 1,
+                                                             base_branch: 'master',
+                                                             head_sha: 'abcdef')
                     @cache.add(pr, ['pkg' => { 'remote_branch' => 'develop' }])
                     refute @cache.changed?(
                         pr, ['pkg' => { 'remote_branch' => 'develop' }]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,72 +5,308 @@ require 'autoproj/daemon'
 require 'autoproj/test'
 require 'minitest/autorun'
 require 'minitest/spec'
-
+require 'fileutils'
+require 'yaml'
+require 'octokit'
+require 'open3'
 require 'rubygems/package'
 
-def create_pull_request(options)
-    Autoproj::Daemon::Github::PullRequest.new(
-        state: options[:state],
-        number: options[:number],
-        title: options[:title],
-        updated_at: options[:updated_at] || Time.now,
-        body: options[:body],
-        base: {
-            ref: options[:base_branch],
-            sha: options[:base_sha],
-            user: {
-                login: options[:base_owner]
-            },
-            repo: {
-                name: options[:base_name]
-            }
-        },
-        head: {
-            ref: options[:head_branch],
-            sha: options[:head_sha],
-            user: {
-                login: options[:head_owner]
-            },
-            repo: {
-                name: options[:head_name]
-            }
-        }
-    )
-end
+module Autoproj
+    module Daemon
+        # Helpers to ease tests
+        module TestHelpers
+            attr_reader :ws
+            attr_reader :installation_manifest
 
-def create_branch(owner, name, options)
-    Autoproj::Daemon::Github::Branch.new(
-        owner, name,
-        name: options[:branch_name],
-        commit: {
-            sha: options[:sha]
-        }
-    )
-end
+            def autoproj_daemon_create_ws(**vcs)
+                @ws = ws_create
+                @installation_manifest_path =
+                    Autoproj::InstallationManifest.path_for_workspace_root(ws.root_dir)
 
-def create_pull_request_event(options)
-    pr = options[:pull_request] || create_pull_request(base_owner: options[:base_owner],
-                                                       base_name: options[:base_name],
-                                                       base_branch: options[:base_branch],
-                                                       state: options[:state])
+                @installation_manifest =
+                    Autoproj::InstallationManifest.new(@installation_manifest_path)
 
-    Autoproj::Daemon::Github::PullRequestEvent.new(
-        payload: {
-            pull_request: pr.instance_variable_get(:@model)
-        },
-        created_at: options[:created_at]
-    )
-end
+                installation_manifest.save
+                return ws unless vcs
 
-def create_push_event(options)
-    Autoproj::Daemon::Github::PushEvent.new(
-        repo: {
-            name: "#{options[:owner]}/#{options[:name]}"
-        },
-        payload: {
-            head: options[:head_sha],
-            ref: "refs/heads/#{options[:branch]}"
-        },
-        created_at: options[:created_at]
-    )
+                ws.manifest.vcs = Autoproj::VCSDefinition.from_raw(vcs)
+                ws.config.set 'manifest_source', vcs.dup, true
+                ws.config.save
+
+                autoproj_daemon_git_init('autoproj', dummy: false)
+                ws
+            end
+
+            def autoproj_daemon_mock_github_api
+                @mock_client = flexmock(Octokit::Client).new_instances
+                @mock_rate_limit = flexmock
+
+                @mock_client.should_receive(:rate_limit).and_return { @mock_rate_limit }
+                @mock_client.should_receive(:rate_limit!).and_return { @mock_rate_limit }
+                @mock_rate_limit
+                    .should_receive(:remaining)
+                    .and_return { @client_rate_limit_remaining }
+
+                @mock_client
+                    .should_receive(:pull_requests)
+                    .and_return do |repo, _options|
+                        @client_pull_requests[repo] || []
+                    end
+
+                @mock_client
+                    .should_receive(:pull_request)
+                    .and_return do |repo, number, _options|
+                        (@client_pull_requests[repo] || [])
+                            .find { |pr| pr['number'] == number }
+                    end
+
+                @mock_client
+                    .should_receive(:branches)
+                    .and_return do |repo, _options|
+                        @client_branches[repo] || []
+                    end
+
+                @mock_client
+                    .should_receive(:user)
+                    .and_return do |user|
+                        @client_users[user] || {}
+                    end
+
+                @mock_client
+                    .should_receive(:user_events)
+                    .and_return do |user|
+                        @client_user_events[user] || []
+                    end
+
+                @mock_client
+                    .should_receive(:organization_events)
+                    .and_return do |organization|
+                        @client_organization_events[organization] || []
+                    end
+
+                @client_rate_limit_remaining = 1000
+                @client_pull_requests = {}
+                @client_branches = {}
+                @client_users = {}
+                @client_organization_events = {}
+                @client_user_events = {}
+            end
+
+            def autoproj_daemon_run_git(*args)
+                _, err, status = Open3.capture3('git', *args)
+                raise err unless status.success?
+            end
+
+            def autoproj_daemon_git_init(dir, dummy: true)
+                dir = File.join(@ws.root_dir, dir)
+                FileUtils.mkdir_p dir if dummy
+
+                Dir.chdir(dir) do
+                    FileUtils.touch(File.join(dir, 'dummy')) if dummy
+
+                    autoproj_daemon_run_git('init')
+                    autoproj_daemon_run_git('remote', 'add', 'autobuild', dir)
+                    autoproj_daemon_run_git('add', '.')
+                    autoproj_daemon_run_git('commit', '-m', 'Initial commit')
+                    autoproj_daemon_run_git('push', '-f', 'autobuild', 'master')
+                end
+            end
+
+            def save_installation_manifest
+                File.write(@installation_manifest_path, YAML.dump(@entries))
+            end
+
+            def autoproj_daemon_add_package(name, vcs)
+                autoproj_daemon_git_init(name)
+
+                vcs = Autoproj::VCSDefinition.from_raw(vcs)
+                entry = {
+                    'name' => name,
+                    'type' => 'Autobuild::CMake',
+                    'vcs' => vcs.to_hash,
+                    'srcdir' => File.join(ws.root_dir, name),
+                    'importdir' => File.join(ws.root_dir, name),
+                    'builddir' => File.join(ws.root_dir, name, 'build'),
+                    'logdir' => File.join(ws.prefix_dir, 'log'),
+                    'prefix' => ws.prefix_dir,
+                    'dependencies' => []
+                }
+
+                @entries ||= []
+                @entries << entry
+
+                save_installation_manifest
+                Autoproj::InstallationManifest::Package.new(
+                    entry['name'], entry['type'], entry['vcs'], entry['srcdir'],
+                    entry['importdir'], entry['prefix'], entry['builddir'],
+                    entry['logdir'], entry['dependencies']
+                )
+            end
+
+            def autoproj_daemon_define_user(user, **options)
+                options = JSON.parse(options.to_json)
+                @client_users ||= {}
+                @client_users[user] = options
+                options
+            end
+
+            def autoproj_daemon_add_package_set(name, vcs)
+                pkg_set = Autoproj::PackageSet.new(
+                    ws,
+                    Autoproj::VCSDefinition.from_raw(vcs),
+                    name: name
+                )
+
+                entry = {
+                    'package_set' => pkg_set.name,
+                    'vcs' => pkg_set.vcs.to_hash,
+                    'raw_local_dir' => pkg_set.raw_local_dir,
+                    'user_local_dir' => pkg_set.user_local_dir
+                }
+
+                @entries ||= []
+                @entries << entry
+
+                save_installation_manifest
+                Autoproj::InstallationManifest::PackageSet.new(
+                    pkg_set.name,
+                    pkg_set.vcs.to_hash,
+                    pkg_set.raw_local_dir,
+                    pkg_set.user_local_dir
+                )
+            end
+
+            def autoproj_daemon_add_push_event(**options)
+                event = Autoproj::Daemon::Github::PushEvent.new(
+                    repo: {
+                        name: "#{options[:owner]}/#{options[:name]}"
+                    },
+                    payload: {
+                        head: options[:head_sha],
+                        ref: "refs/heads/#{options[:branch]}"
+                    },
+                    created_at: options[:created_at]
+                )
+                return event unless @mock_client
+
+                if @mock_client.user(event.owner)['type'] == 'Organization'
+                    @client_orgaization_events ||= {}
+                    @client_orgaization_events[event.owner] ||= []
+                    @client_orgaization_events[event.owner] << event.model
+                else
+                    @client_user_events ||= {}
+                    @client_user_events[event.owner] ||= []
+                    @client_user_events[event.owner] << event.model
+                end
+                event
+            end
+
+            def autoproj_daemon_create_pull_request(options)
+                Autoproj::Daemon::Github::PullRequest.new(
+                    state: options[:state],
+                    number: options[:number],
+                    title: options[:title],
+                    updated_at: options[:updated_at] || Time.now,
+                    body: options[:body],
+                    base: {
+                        ref: options[:base_branch],
+                        sha: options[:base_sha],
+                        user: {
+                            login: options[:base_owner]
+                        },
+                        repo: {
+                            name: options[:base_name]
+                        }
+                    },
+                    head: {
+                        ref: options[:head_branch],
+                        sha: options[:head_sha],
+                        user: {
+                            login: options[:head_owner]
+                        },
+                        repo: {
+                            name: options[:head_name]
+                        }
+                    }
+                )
+            end
+
+            def autoproj_daemon_add_pull_request_event(**options)
+                pr = options[:pull_request] || autoproj_daemon_create_pull_request(
+                    base_owner: options[:base_owner],
+                    base_name: options[:base_name],
+                    base_branch: options[:base_branch],
+                    state: options[:state]
+                )
+                event = Autoproj::Daemon::Github::PullRequestEvent.new(
+                    payload: {
+                        pull_request: pr.instance_variable_get(:@model)
+                    },
+                    created_at: options[:created_at]
+                )
+                return event unless @mock_client
+
+                if @mock_client.user(pr.base_owner)['type'] == 'Organization'
+                    @client_orgaization_events ||= {}
+                    @client_orgaization_events[pr.base_owner] ||= []
+                    @client_orgaization_events[pr.base_owner] << event.model
+                else
+                    @client_user_events ||= {}
+                    @client_user_events[pr.base_owner] ||= []
+                    @client_user_events[pr.base_owner] << event.model
+                end
+                event
+            end
+
+            def autoproj_daemon_add_pull_request(**options)
+                pr = Autoproj::Daemon::Github::PullRequest.new(
+                    state: options[:state],
+                    number: options[:number],
+                    title: options[:title],
+                    updated_at: options[:updated_at] || Time.now,
+                    body: options[:body],
+                    base: {
+                        ref: options[:base_branch],
+                        sha: options[:base_sha],
+                        user: {
+                            login: options[:base_owner]
+                        },
+                        repo: {
+                            name: options[:base_name]
+                        }
+                    },
+                    head: {
+                        ref: options[:head_branch],
+                        sha: options[:head_sha],
+                        user: {
+                            login: options[:head_owner]
+                        },
+                        repo: {
+                            name: options[:head_name]
+                        }
+                    }
+                )
+
+                @client_pull_requests ||= {}
+                @client_pull_requests["#{pr.base_owner}/#{pr.base_name}"] ||= []
+                @client_pull_requests["#{pr.base_owner}/#{pr.base_name}"] << pr.model
+                pr
+            end
+
+            def autoproj_daemon_add_branch(owner, name, options)
+                branch = Autoproj::Daemon::Github::Branch.new(
+                    owner, name,
+                    name: options[:branch_name],
+                    commit: {
+                        sha: options[:sha]
+                    }
+                )
+
+                @client_branches ||= {}
+                @client_branches["#{branch.owner}/#{branch.name}"] ||= []
+                @client_branches["#{branch.owner}/#{branch.name}"] << branch.model
+                branch
+            end
+        end
+    end
 end


### PR DESCRIPTION
This refactors the test suite and extends it by adding helpers to hopefully make it easier for others to write tests and the overall development/maintenance of the daemon. In addition to that, the new helpers drastically reduce the number of mocks that are necessary during tests. The only mock that is really required after this patch is the github api itself (Octokit::Client), everything else can be tested integrated if deemed appropriate. 