### PR TITLE
validate push and pull request events using the direct API before triggering

### DIFF
--- a/lib/autoproj/daemon/github/pull_request.rb
+++ b/lib/autoproj/daemon/github/pull_request.rb
@@ -18,6 +18,10 @@ module Autoproj
                     @model['state'] == 'open'
                 end
 
+                def open=(flag)
+                    @model['state'] = flag ? 'open' : 'closed'
+                end
+
                 # @return [Integer]
                 def number
                     @model['number']
@@ -81,7 +85,7 @@ module Autoproj
                 end
 
                 def ==(other)
-                    model == other.model
+                    @model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github/pull_request_event.rb
+++ b/lib/autoproj/daemon/github/pull_request_event.rb
@@ -22,6 +22,15 @@ module Autoproj
                 def created_at
                     Time.parse(@model['created_at'])
                 end
+
+                def initialize_copy(_)
+                    super
+                    @model = @model.dup
+                end
+
+                def ==(other)
+                    @model == other.model
+                end
             end
         end
     end

--- a/lib/autoproj/daemon/github/push_event.rb
+++ b/lib/autoproj/daemon/github/push_event.rb
@@ -14,6 +14,11 @@ module Autoproj
                     @model = JSON.parse(model.to_json)
                 end
 
+                def initialize_copy(_)
+                    super
+                    @model = @model.dup
+                end
+
                 def author
                     @model['actor']['login']
                 end
@@ -30,12 +35,20 @@ module Autoproj
                     @model['payload']['ref'].split('/')[2]
                 end
 
+                def head_sha=(sha)
+                    @model['payload']['head'] = sha.to_str
+                end
+
                 def head_sha
                     @model['payload']['head']
                 end
 
                 def created_at
                     Time.parse(@model['created_at'])
+                end
+
+                def ==(other)
+                    model == other.model
                 end
             end
         end

--- a/test/autoproj/daemon/test_github_watcher.rb
+++ b/test/autoproj/daemon/test_github_watcher.rb
@@ -589,15 +589,15 @@ module Autoproj
 
                     watcher.handle_owner_events('tidewise', @events)
                 end
-                it 'ignores events on whose SHA does not match the state of '\
-                   'the current branch' do
-                    @events << autoproj_daemon_add_push_event(
+                it 'updates the event\'s SHA using the current branch state' do
+                    ev = autoproj_daemon_add_push_event(
                         owner: 'rock-core',
                         name: 'drivers-gps_ublox',
                         branch: 'master',
                         head_sha: '1234',
                         created_at: Time.utc(2019, 'sep', 22, 23, 53, 35)
                     )
+                    @events << ev
                     autoproj_daemon_add_branch(
                         'rock-core', 'drivers-gps_ublox',
                         branch_name: 'master', sha: '3456'
@@ -605,9 +605,11 @@ module Autoproj
 
                     add_package('drivers/gps_ublox', 'rock-core', 'drivers-gps_ublox')
 
+                    expected_ev = ev.dup
+                    expected_ev.head_sha = '3456'
                     flexmock(watcher)
                         .should_receive(:handle_push_events)
-                        .with([]).once
+                        .with([expected_ev]).once
 
                     watcher.handle_owner_events('rock-core', @events)
                 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -261,7 +261,8 @@ module Autoproj
                     base_owner: options[:base_owner],
                     base_name: options[:base_name],
                     base_branch: options[:base_branch],
-                    state: options[:state]
+                    state: options[:state],
+                    number: options[:number]
                 )
                 event = Autoproj::Daemon::Github::PullRequestEvent.new(
                     payload: {


### PR DESCRIPTION
We regularly have push events to master whose SHA differs from the
one that is actually at HEAD. Filter these events out in order to
avoid triggering in a loop.