### PR TITLE
turn autoproj-daemon into a buildbot change source instead of directly triggering builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ autoproj plugin install autoproj-daemon
 
 From within an autoproj workspace
 
+The daemon will get its configuration from the workspace's configuration file.
+It requires the following keys:
+
+~~~
+daemon_project: PROJECT_NAME
+daemon_api_key: GITHUB_API_KEY
+daemon_polling_period: POLLING_PERIOD_IN_SECONDS
+daemon_buildbot_host: BUILDBOT_HOST
+daemon_buildbot_port: 8666
+~~~
+
 ## Usage
 
 ## Development

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -49,7 +49,9 @@ module Autoproj
             # @return [Boolean]
             def build_pull_request(pull_request)
                 base_repository = "#{pull_request.base_owner}/#{pull_request.base_name}"
-                branch_name = BuildconfManager.branch_name_by_pull_request(pull_request)
+                branch_name = BuildconfManager.branch_name_by_pull_request(
+                    @project, pull_request
+                )
 
                 build(
                     author: pull_request.head_owner,

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -115,6 +115,7 @@ module Autoproj
                     revlink: revlink,
                     when_timestamp: when_timestamp
                 }
+                Autoproj.message "#{options}"
                 request.set_form_data(options)
 
                 Autoproj.message "Triggering build on #{branch}"

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -48,7 +48,7 @@ module Autoproj
             # @param [Github::PullRequest] options
             # @return [Boolean]
             def build_pull_request(pull_request)
-                base_repository = "#{pull_request.base_owner}/#{pull_request.base_name}"
+                base_repository = "https://github.com/#{pull_request.base_owner}/#{pull_request.base_name}"
                 branch_name = BuildconfManager.branch_name_by_pull_request(
                     @project, pull_request
                 )
@@ -61,7 +61,7 @@ module Autoproj
                     committer: pull_request.head_owner,
                     repository: base_repository,
                     revision: pull_request.head_sha,
-                    revlink: "https://github.com/#{base_repository}/pull/#{pull_request.number}",
+                    revlink: "#{base_repository}/pull/#{pull_request.number}",
                     when_timestamp: pull_request.updated_at.tv_sec
                 )
             end
@@ -69,7 +69,7 @@ module Autoproj
             # @param [Github::PushEvent] options
             # @return [Boolean]
             def build_mainline_push_event(push_event)
-                repository = "#{push_event.owner}/#{push_event.name}"
+                repository = "https://github.com/#{push_event.owner}/#{push_event.name}"
 
                 build(
                     # Codebase is a single codebase - i.e. single repo, but
@@ -81,7 +81,7 @@ module Autoproj
                     committer: push_event.author,
                     repository: repository,
                     revision: push_event.head_sha,
-                    revlink: "https://github.com/#{repository}",
+                    revlink: repository,
                     when_timestamp: push_event.created_at.tv_sec
                 )
             end

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -119,7 +119,14 @@ module Autoproj
 
                 Autoproj.message "Triggering build on #{branch}"
 
-                response = http.request(request)
+                response =
+                    begin
+                        http.request(request)
+                    rescue SystemCallError => e
+                        Autoproj.error "Failed to connect to buildbot: #{e}"
+                        return false
+                    end
+
                 if response.code == '200'
                     Autoproj.message 'OK'
                     return true

--- a/lib/autoproj/daemon/buildconf_manager.rb
+++ b/lib/autoproj/daemon/buildconf_manager.rb
@@ -49,8 +49,8 @@ module Autoproj
             #     with all package repositories to watch
             # @param [Autoproj::Daemon::PullRequestCache] cache Pull request cache
             # @param [Autoproj::Workspace] workspace Current workspace
-            def initialize(buildconf, client, packages, cache, workspace)
-                @bb = Buildbot.new(workspace)
+            def initialize(buildconf, client, packages, cache, workspace, project: nil)
+                @bb = Buildbot.new(workspace, project: project)
                 @buildconf = buildconf
                 @client = client
                 @packages = packages

--- a/lib/autoproj/extensions/configuration.rb
+++ b/lib/autoproj/extensions/configuration.rb
@@ -4,6 +4,19 @@ module Autoproj
     module Extensions
         # Autoproj's main configuration scope
         module Configuration
+            # The project name
+            #
+            # Passed as-is to buildbot's change system to recognize which
+            # builder to use
+            def daemon_project
+                get('daemon_project', nil)
+            end
+
+            # Sets the project name
+            def daemon_project=(name)
+                set('daemon_project', name, true)
+            end
+
             # Sets the github api key to be used for authentication.
             # @param [String] api_key the github api key
             def daemon_api_key=(api_key)
@@ -55,20 +68,6 @@ module Autoproj
             # @return [Integer]
             def daemon_buildbot_port
                 get('daemon_buildbot_port', 8010)
-            end
-
-            # The buildbot force scheduler name
-            #
-            # @return [String]
-            def daemon_buildbot_scheduler
-                get('daemon_buildbot_scheduler', 'build-force')
-            end
-
-            # Sets the buildbot force scheduler name
-            # @param [String] scheduler Buildbot force scheduler name
-            # @return [void]
-            def daemon_buildbot_scheduler=(scheduler)
-                set('daemon_buildbot_scheduler', scheduler, true)
             end
 
             # Longest period to consider PRs and events (in days)

--- a/test/autoproj/cli/test_daemon.rb
+++ b/test/autoproj/cli/test_daemon.rb
@@ -24,6 +24,32 @@ module Autoproj
                 @cli = Daemon.new(ws)
             end
 
+            it 'sets the project to an empty string if none is given' do
+                assert_equal '', @cli.bb.project
+                ws.config.set 'daemon_api_key', 'something', true
+                @cli.prepare
+                assert_equal '', @cli.bb.project
+            end
+
+            it 'computes the buildbot project name from the configuration' do
+                ws.config.set 'daemon_project', 'somename', true
+                cli = Daemon.new(ws, load_config: false)
+                assert_equal 'somename', cli.bb.project
+                ws.config.set 'daemon_api_key', 'something', true
+                cli.prepare
+                assert_equal 'somename', cli.buildconf_manager.bb.project
+            end
+
+            it 'appends the manifest name if it is not mainline' do
+                ws.config.set 'daemon_project', 'somename', true
+                ws.config.set 'manifest_name', 'manifest.subsystem'
+                cli = Daemon.new(ws, load_config: false)
+                assert_equal 'somename_subsystem', cli.bb.project
+                ws.config.set 'daemon_api_key', 'something', true
+                cli.prepare
+                assert_equal 'somename_subsystem', cli.buildconf_manager.bb.project
+            end
+
             # rubocop: disable Metrics/BlockLength
             describe '#resolve_packages' do
                 it 'returns an array of all packages and package sets' do

--- a/test/autoproj/cli/test_daemon.rb
+++ b/test/autoproj/cli/test_daemon.rb
@@ -24,11 +24,11 @@ module Autoproj
                 @cli = Daemon.new(ws)
             end
 
-            it 'sets the project to an empty string if none is given' do
-                assert_equal '', @cli.bb.project
+            it 'sets the project to \'daemon\' if none is given' do
+                assert_equal 'daemon', @cli.bb.project
                 ws.config.set 'daemon_api_key', 'something', true
                 @cli.prepare
-                assert_equal '', @cli.bb.project
+                assert_equal 'daemon', @cli.bb.project
             end
 
             it 'computes the buildbot project name from the configuration' do
@@ -434,7 +434,8 @@ module Autoproj
                         }
                     ]
 
-                    @cli = Daemon.new(ws)
+                    ws.config.set 'daemon_project', 'myproject', true
+                    @cli = Daemon.new(ws, load_config: false)
 
                     ws.config.daemon_api_key = 'foobar'
                     cli.prepare
@@ -505,10 +506,11 @@ module Autoproj
                     it 'handles errors if buildconf branch does not exist' do
                         flexmock(cli).should_receive('client.delete_branch_by_name')
                                      .with('rock-core', 'buildconf',
-                                           'autoproj/rock-core/'\
+                                           'autoproj/myproject/rock-core/'\
                                            'drivers-iodrivers_base/pulls/1')
                                      .and_raise(Octokit::UnprocessableEntity)
 
+                        assert_equal 'myproject', cli.project
                         cli.handle_pull_request_event(@pull_request_event)
                     end
                     it 'deletes branch and removes PR from cache' do
@@ -516,8 +518,8 @@ module Autoproj
 
                         flexmock(cli).should_receive('client.delete_branch_by_name')
                                      .with('rock-core', 'buildconf',
-                                           'autoproj/rock-core/drivers-iodrivers_base/'\
-                                           'pulls/1')
+                                           'autoproj/myproject/rock-core/'\
+                                           'drivers-iodrivers_base/pulls/1')
 
                         refute cli.cache.changed?(@pull_request, @overrides)
                         cli.handle_pull_request_event(@pull_request_event)

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -77,7 +77,7 @@ module Autoproj
                         category: 'pull_request',
                         codebase: '',
                         committer: 'contributor',
-                        repository: 'tidewise/drivers-gps_ublox',
+                        repository: 'https://github.com/tidewise/drivers-gps_ublox',
                         revision: 'abcdef',
                         revlink: 'https://github.com/tidewise/drivers-gps_ublox/pull/22',
                         when_timestamp: now.tv_sec
@@ -107,7 +107,7 @@ module Autoproj
                         category: 'push',
                         codebase: '',
                         committer: 'g-arjones',
-                        repository: 'tidewise/drivers-gps_ublox',
+                        repository: 'https://github.com/tidewise/drivers-gps_ublox',
                         revision: 'abcdef',
                         revlink: 'https://github.com/tidewise/drivers-gps_ublox',
                         when_timestamp: now.tv_sec

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -51,7 +51,19 @@ module Autoproj
 
                     flexmock(Net::HTTP)
                         .new_instances
-                        .should_receive('request').and_return(response)
+                        .should_receive('request')
+                        .and_return(response)
+
+                    refute bb.build
+                end
+                it 'returns false if the request fails because of network errors' do
+                    ws.config.daemon_buildbot_host = 'bb-master'
+                    ws.config.daemon_buildbot_port = 8666
+
+                    flexmock(Net::HTTP)
+                        .new_instances
+                        .should_receive('request')
+                        .and_raise(Errno::ECONNREFUSED)
 
                     refute bb.build
                 end

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -73,7 +73,7 @@ module Autoproj
                     now = Time.now
                     flexmock(bb).should_receive(:build).with(
                         author: 'contributor',
-                        branch: 'autoproj/tidewise/drivers-gps_ublox/pulls/22',
+                        branch: 'autoproj/wetpaint/tidewise/drivers-gps_ublox/pulls/22',
                         category: 'pull_request',
                         codebase: '',
                         committer: 'contributor',

--- a/test/autoproj/daemon/test_buildconf_manager.rb
+++ b/test/autoproj/daemon/test_buildconf_manager.rb
@@ -30,7 +30,8 @@ module Autoproj
                 )
 
                 @manager = BuildconfManager.new(
-                    @buildconf, @client, @packages, @cache, @ws
+                    @buildconf, @client, @packages, @cache, @ws,
+                    project: 'myproject'
                 )
             end
 
@@ -138,12 +139,14 @@ module Autoproj
                     )
                     stale = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/12',
+                        branch_name: 'autoproj/myproject/rock-core/'\
+                                     'drivers-iodrivers_base/pulls/12',
                         sha: 'abcdef'
                     )
                     autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-gps_base/pulls/55',
+                        branch_name: 'autoproj/myproject/rock-core/'\
+                                     'drivers-gps_base/pulls/55',
                         sha: 'ghijkl'
                     )
 
@@ -172,6 +175,27 @@ module Autoproj
                     @manager.delete_stale_branches
                 end
                 # rubocop: enable Metrics/BlockLength
+
+                it 'deletes branches that start with autoproj/ but do not match the expected pattern' do
+                    stale = []
+                    stale << autoproj_daemon_add_branch(
+                        'rock-core', 'buildconf',
+                        branch_name: 'autoproj/rock-core/'\
+                                     'drivers-iodrivers_base/pulls/12',
+                        sha: 'abcdef'
+                    )
+                    stale << autoproj_daemon_add_branch(
+                        'rock-core', 'buildconf',
+                        branch_name: 'autoproj/something',
+                        sha: 'abcdef'
+                    )
+                    @manager.update_branches
+                    @manager.update_pull_requests
+
+                    flexmock(@client).should_receive(:delete_branch).with(stale[0]).once
+                    flexmock(@client).should_receive(:delete_branch).with(stale[1]).once
+                    @manager.delete_stale_branches
+                end
             end
 
             describe '#create_missing_branches' do # rubocop: disable Metrics/BlockLength
@@ -179,7 +203,8 @@ module Autoproj
                 it 'creates branches for open PRs' do
                     existing_branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/17',
+                        branch_name: 'autoproj/myproject/rock-core/'\
+                                     'drivers-iodrivers_base/pulls/17',
                         sha: 'abcdef'
                     )
 
@@ -206,7 +231,8 @@ module Autoproj
                     @manager.update_branches
                     @manager.update_pull_requests
 
-                    new_branch_name = 'autoproj/rock-core/drivers-gps_base/pulls/55'
+                    new_branch_name = 'autoproj/myproject/'\
+                                      'rock-core/drivers-gps_base/pulls/55'
                     new_branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
                         branch_name: new_branch_name,
@@ -229,7 +255,8 @@ module Autoproj
                 it 'does not trigger if PR did not change' do
                     branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/12',
+                        branch_name: 'autoproj/myproject/'\
+                                     'rock-core/drivers-iodrivers_base/pulls/12',
                         sha: 'abcdef'
                     )
 
@@ -271,7 +298,8 @@ module Autoproj
                 it 'triggers if overrides changed' do
                     branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/12',
+                        branch_name: 'autoproj/myproject/'\
+                                     'rock-core/drivers-iodrivers_base/pulls/12',
                         sha: 'abcdef'
                     )
 
@@ -295,7 +323,8 @@ module Autoproj
                     @manager.update_branches
                     @manager.update_pull_requests
 
-                    branch_name = 'autoproj/rock-core/drivers-iodrivers_base/pulls/12'
+                    branch_name = 'autoproj/myproject/'\
+                                  'rock-core/drivers-iodrivers_base/pulls/12'
                     expected_overrides = [{
                         'drivers/iodrivers_base' => {
                             'remote_branch' => 'refs/pull/12/merge'
@@ -312,7 +341,8 @@ module Autoproj
                 it 'triggers if PR head sha changed' do
                     branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/12',
+                        branch_name: 'autoproj/myproject/'\
+                                     'rock-core/drivers-iodrivers_base/pulls/12',
                         sha: 'abcdef'
                     )
 
@@ -352,7 +382,8 @@ module Autoproj
                     @cache.add(pr_cached, overrides)
                     @manager.update_branches
                     @manager.update_pull_requests
-                    branch_name = 'autoproj/rock-core/drivers-iodrivers_base/pulls/12'
+                    branch_name = 'autoproj/myproject/'\
+                                  'rock-core/drivers-iodrivers_base/pulls/12'
 
                     flexmock(@manager.bb).should_receive(:build_pull_request)
                                          .with(pr).once
@@ -364,7 +395,8 @@ module Autoproj
                 it 'triggers if PR base branch changed' do
                     branch = autoproj_daemon_add_branch(
                         'rock-core', 'buildconf',
-                        branch_name: 'autoproj/rock-core/drivers-iodrivers_base/pulls/12',
+                        branch_name: 'autoproj/myproject/'\
+                                     'rock-core/drivers-iodrivers_base/pulls/12',
                         sha: 'abcdef'
                     )
 
@@ -405,7 +437,8 @@ module Autoproj
                     @manager.update_branches
                     @manager.update_pull_requests
 
-                    branch_name = 'autoproj/rock-core/drivers-iodrivers_base/pulls/12'
+                    branch_name = 'autoproj/myproject/'\
+                                  'rock-core/drivers-iodrivers_base/pulls/12'
                     flexmock(@manager.bb).should_receive(:build_pull_request)
                                          .with(pr).once
                     flexmock(@manager).should_receive(:commit_and_push_overrides)

--- a/test/autoproj/test_configuration.rb
+++ b/test/autoproj/test_configuration.rb
@@ -54,14 +54,20 @@ module Autoproj
             end
         end
 
-        describe '#daemon_buildbot_scheduler' do
-            it 'sets buildbot scheduler' do
-                @config.daemon_buildbot_scheduler = 'foo-scheduler'
-                assert_equal 'foo-scheduler', @config.daemon_buildbot_scheduler
+        describe '#daemon_project' do
+            it 'sets buildbot project' do
+                @config.daemon_project = 'name'
+                assert_equal 'name', @config.get('daemon_project')
+                assert_equal 'name', @config.daemon_project
             end
 
-            it 'returns build-force if buildbot scheduler not set' do
-                assert_equal 'build-force', @config.daemon_buildbot_scheduler
+            it 'returns the value of the daemon_project config key' do
+                @config.set 'daemon_project', 'name'
+                assert_equal 'name', @config.daemon_project
+            end
+
+            it 'returns nil if not set' do
+                assert_nil @config.daemon_project
             end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -219,7 +219,10 @@ module Autoproj
                         head: options[:head_sha],
                         ref: "refs/heads/#{options[:branch]}"
                     },
-                    created_at: options[:created_at]
+                    actor: {
+                        login: options[:author]
+                    },
+                    created_at: options[:created_at] || Time.now
                 )
 
                 autoproj_daemon_add_event(event.owner, event.model)


### PR DESCRIPTION
There are a few important advantages in doing so:
- one can see which changes triggered a particular build
- allows to filter what builds actually gets triggered at the
  buildbot level, with no changes needed at the autoproj-daemon level.
- autoproj stops having to know about builds. It becomes a buildbot
  change source, and buildbot takes care of reacting to the changes.

I have now 7 manifests in a single buildconf, managing both the main development build and separate builds for each machine in the system. This change allowed us to decide where to build only mainline, where to build pull request, to ignore pull requests from certain packages we're not interested in ....

It really adds flexibility at the buildbot configuration level, without needing to change autoproj-daemon (which, by nature, is less visible)