### PR TITLE
Refactor event handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,18 @@ inherit_from: .rubocop_todo.yml
 inherit_gem:
   rubocop-rock: defaults.yml
 
+inherit_mode:
+  merge:
+  - AllowedNames
+
+Naming/MethodParameterName:
+  AllowedNames:
+  - ws
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/test_*.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'test/**/test_*.rb'

--- a/autoproj-daemon.gemspec
+++ b/autoproj-daemon.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "autoproj/daemon/version"
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
     spec.name = "autoproj-daemon"
     spec.version       = Autoproj::Daemon::VERSION
     spec.authors       = ["Gabriel Arjones"]
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
     spec.require_paths = ["lib"]
 
     spec.add_dependency "autoproj", "~> 2.12"
+    spec.add_dependency "backports"
     spec.add_dependency "faraday-http-cache"
     spec.add_dependency "octokit"
     spec.add_development_dependency "bundler"

--- a/lib/autoproj/cli/daemon.rb
+++ b/lib/autoproj/cli/daemon.rb
@@ -121,10 +121,10 @@ module Autoproj
                     handle_mainline_modifications(modified_mainlines)
                 end
 
-                modified_pull_requests.each do |pull_request, events|
+                modified_pull_requests.each_key do |pull_request|
                     next if buildconf_pull_request?(pull_request)
 
-                    handle_pull_request_modifications(pull_request, events)
+                    handle_pull_request_modifications(pull_request)
                 end
             end
 
@@ -170,7 +170,7 @@ module Autoproj
             #
             # @param [Daemon::Github::PullRequest] pull_request
             # @return [void]
-            def handle_pull_request_modifications(pull_request, events)
+            def handle_pull_request_modifications(pull_request)
                 # Check whether the pull request closed, and if we're aware
                 unless pull_request.open?
                     if cache.include?(pull_request)
@@ -183,7 +183,7 @@ module Autoproj
                     return handle_pull_request_opened(pull_request)
                 end
 
-                handle_pull_request_changes(pull_request, events)
+                handle_pull_request_changes(pull_request)
             end
 
             # @api private
@@ -192,7 +192,7 @@ module Autoproj
             #
             # @param [Daemon::Github::PullRequest] pull_request
             # @return [void]
-            def handle_pull_request_changes(pull_request, _events)
+            def handle_pull_request_changes(pull_request)
                 overrides = buildconf_manager.overrides_for_pull_request(pull_request)
                 return unless cache.changed?(pull_request, overrides)
 

--- a/lib/autoproj/daemon.rb
+++ b/lib/autoproj/daemon.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "backports/2.5.0/hash/transform_keys"
+
 require "autoproj/cli/daemon"
 require "autoproj/cli/main_daemon"
 require "autoproj/daemon/github_watcher"

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -45,6 +45,10 @@ module Autoproj
                 )
             end
 
+            # Publish a change indicating that a pull request was modified
+            #
+            # @param [Github::PullRequest] pull_request
+            # @return [Boolean] true if the posting was successful, false otherwise
             def post_pull_request_changes(pull_request)
                 base_repository =
                     "https://github.com/#{pull_request.base_owner}/"\
@@ -66,6 +70,11 @@ module Autoproj
                 )
             end
 
+            # Publish changes that happened to a mainline branch
+            #
+            # @param [PackageRepository] _package
+            # @param [Array<Github::PushEvent>] events
+            # @return [Boolean]
             def post_mainline_changes(_package, events)
                 events.each do |push_event|
                     repository =
@@ -87,7 +96,6 @@ module Autoproj
                 end
             end
 
-            # @param [Hash] options
             # @return [Boolean]
             def post_change(
                 author: "",

--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -45,9 +45,7 @@ module Autoproj
                 )
             end
 
-            # @param [Github::PullRequest] options
-            # @return [Boolean]
-            def build_pull_request(pull_request)
+            def post_pull_request_changes(pull_request)
                 base_repository =
                     "https://github.com/#{pull_request.base_owner}/"\
                     "#{pull_request.base_name}"
@@ -55,7 +53,7 @@ module Autoproj
                     @project, pull_request
                 )
 
-                build(
+                post_change(
                     author: pull_request.head_owner,
                     branch: branch_name,
                     category: "pull_request",
@@ -68,29 +66,30 @@ module Autoproj
                 )
             end
 
-            # @param [Github::PushEvent] options
-            # @return [Boolean]
-            def build_mainline_push_event(push_event)
-                repository = "https://github.com/#{push_event.owner}/#{push_event.name}"
+            def post_mainline_changes(_package, events)
+                events.each do |push_event|
+                    repository =
+                        "https://github.com/#{push_event.owner}/#{push_event.name}"
 
-                build(
-                    # Codebase is a single codebase - i.e. single repo, but
-                    # tracked across forks
-                    author: push_event.author,
-                    branch: "master",
-                    category: "push",
-                    codebase: "",
-                    committer: push_event.author,
-                    repository: repository,
-                    revision: push_event.head_sha,
-                    revlink: repository,
-                    when_timestamp: push_event.created_at.tv_sec
-                )
+                    post_change(
+                        # Codebase is a single codebase - i.e. single repo, but
+                        # tracked across forks
+                        author: push_event.author,
+                        branch: "master",
+                        category: "push",
+                        codebase: "",
+                        committer: push_event.author,
+                        repository: repository,
+                        revision: push_event.head_sha,
+                        revlink: repository,
+                        when_timestamp: push_event.created_at.tv_sec
+                    )
+                end
             end
 
             # @param [Hash] options
             # @return [Boolean]
-            def build(
+            def post_change(
                 author: "",
                 branch: "master",
                 category: "",

--- a/lib/autoproj/daemon/buildconf_manager.rb
+++ b/lib/autoproj/daemon/buildconf_manager.rb
@@ -275,7 +275,7 @@ module Autoproj
             # @return [void]
             def trigger_build(branch)
                 pr = pull_request_by_branch(branch)
-                bb.build_pull_request(pr)
+                bb.post_pull_request_changes(pr)
             end
 
             # @param [Array<Github::Branch>] branches
@@ -289,7 +289,7 @@ module Autoproj
                     Autoproj.message "Updating "\
                                      "#{pr.base_owner}/#{pr.base_name}##{pr.number}"
                     commit_and_push_overrides(branch.branch_name, overrides)
-                    bb.build_pull_request(pr)
+                    bb.post_pull_request_changes(pr)
                     cache.add(pr, overrides)
                 end
             end

--- a/lib/autoproj/daemon/github/branch.rb
+++ b/lib/autoproj/daemon/github/branch.rb
@@ -1,25 +1,31 @@
 # frozen_string_literal: true
 
-require "json"
+require "autoproj/daemon/github/json_facade"
 
 module Autoproj
     module Daemon
         module Github
             # A branch model representation
-            class Branch
+            class Branch < JSONFacade
                 # @return [String]
                 attr_reader :owner
 
                 # @return [String]
                 attr_reader :name
 
-                # @return [Hash]
-                attr_reader :model
+                def self.from_ruby_hash(owner, name, model)
+                    from_json_string(owner, name, model.to_json)
+                end
+
+                def self.from_json_string(owner, name, model)
+                    new(owner, name, JSON.parse(model))
+                end
 
                 def initialize(owner, name, model)
+                    super(model)
+
                     @owner = owner
                     @name = name
-                    @model = JSON.parse(model.to_json)
                 end
 
                 # @return [String]
@@ -30,11 +36,6 @@ module Autoproj
                 # @return [String]
                 def sha
                     @model["commit"]["sha"]
-                end
-
-                # @return [Boolean]
-                def ==(other)
-                    model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github/client.rb
+++ b/lib/autoproj/daemon/github/client.rb
@@ -56,7 +56,7 @@ module Autoproj
                 def pull_requests(owner, name, options = {})
                     with_retry do
                         @client.pull_requests("#{owner}/#{name}", options).map do |pr|
-                            PullRequest.new(pr.to_hash)
+                            PullRequest.from_ruby_hash(pr.to_hash)
                         end
                     end
                 end
@@ -64,7 +64,7 @@ module Autoproj
                 # @return [PullRequest]
                 def pull_request(owner, name, number, options = {})
                     with_retry do
-                        PullRequest.new(
+                        PullRequest.from_ruby_hash(
                             @client.pull_request(
                                 "#{owner}/#{name}", number, options
                             ).to_hash
@@ -90,9 +90,9 @@ module Autoproj
                             next unless %w[PullRequestEvent PushEvent].include? type
 
                             if type == "PullRequestEvent"
-                                PullRequestEvent.new(event.to_hash)
+                                PullRequestEvent.from_ruby_hash(event.to_hash)
                             else
-                                PushEvent.new(event.to_hash)
+                                PushEvent.from_ruby_hash(event.to_hash)
                             end
                         end.compact
                     end
@@ -102,7 +102,7 @@ module Autoproj
                 def branches(owner, name, options = {})
                     with_retry do
                         @client.branches("#{owner}/#{name}", options).map do |branch|
-                            Branch.new(owner, name, branch.to_hash)
+                            Branch.from_ruby_hash(owner, name, branch.to_hash)
                         end
                     end
                 end
@@ -138,7 +138,7 @@ module Autoproj
                             "#{owner}/#{name}", branch_name
                         ).to_hash
                     end
-                    Branch.new(owner, name, model)
+                    Branch.from_ruby_hash(owner, name, model)
                 end
 
                 # @return [Integer]

--- a/lib/autoproj/daemon/github/json_facade.rb
+++ b/lib/autoproj/daemon/github/json_facade.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+
+module Autoproj
+    module Daemon
+        module Github
+            # Base class for classes that provide a friendly interface on top
+            # of JSON objects
+            class JSONFacade
+                # @return [Hash]
+                attr_reader :model
+
+                def self.from_ruby_hash(hash)
+                    from_json_string(hash.to_json)
+                end
+
+                def self.from_json_string(string)
+                    new(JSON.parse(string))
+                end
+
+                def initialize(model)
+                    @model = model
+                end
+
+                def ==(other)
+                    @model == other.model
+                end
+
+                def eql?(other)
+                    @model.eql?(other.model)
+                end
+
+                def hash
+                    @model.hash
+                end
+
+                def initialize_copy(_)
+                    super
+                    @model = @model.dup
+                end
+            end
+        end
+    end
+end

--- a/lib/autoproj/daemon/github/pull_request.rb
+++ b/lib/autoproj/daemon/github/pull_request.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-require "json"
-require "time"
+require "autoproj/daemon/github/json_facade"
 
 module Autoproj
     module Daemon
         module Github
             # A PullRequest model representation
-            class PullRequest
-                attr_reader :model
-                def initialize(model)
-                    @model = JSON.parse(model.to_json)
-                end
-
+            class PullRequest < JSONFacade
                 # @return [Boolean]
                 def open?
                     @model["state"] == "open"
@@ -82,10 +76,6 @@ module Autoproj
                 # @return [String]
                 def body
                     @model["body"]
-                end
-
-                def ==(other)
-                    @model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github/pull_request_event.rb
+++ b/lib/autoproj/daemon/github/pull_request_event.rb
@@ -1,35 +1,19 @@
 # frozen_string_literal: true
 
+require "autoproj/daemon/github/json_facade"
 require "autoproj/daemon/github/pull_request"
-require "json"
 
 module Autoproj
     module Daemon
         module Github
             # A PullRequestEvent model representation
-            class PullRequestEvent
-                # @return [Hash]
-                attr_reader :model
-
-                def initialize(model)
-                    @model = JSON.parse(model.to_json)
-                end
-
+            class PullRequestEvent < JSONFacade
                 def pull_request
                     PullRequest.new(@model["payload"]["pull_request"])
                 end
 
                 def created_at
                     Time.parse(@model["created_at"])
-                end
-
-                def initialize_copy(_)
-                    super
-                    @model = @model.dup
-                end
-
-                def ==(other)
-                    @model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github/push_event.rb
+++ b/lib/autoproj/daemon/github/push_event.rb
@@ -1,24 +1,12 @@
 # frozen_string_literal: true
 
-require "json"
+require "autoproj/daemon/github/json_facade"
 
 module Autoproj
     module Daemon
         module Github
             # A PushEvent model representation
-            class PushEvent
-                # @return [Hash]
-                attr_reader :model
-
-                def initialize(model)
-                    @model = JSON.parse(model.to_json)
-                end
-
-                def initialize_copy(_)
-                    super
-                    @model = @model.dup
-                end
-
+            class PushEvent < JSONFacade
                 def author
                     @model["actor"]["login"]
                 end
@@ -45,10 +33,6 @@ module Autoproj
 
                 def created_at
                     Time.parse(@model["created_at"])
-                end
-
-                def ==(other)
-                    model == other.model
                 end
             end
         end

--- a/lib/autoproj/daemon/github_watcher.rb
+++ b/lib/autoproj/daemon/github_watcher.rb
@@ -260,9 +260,13 @@ module Autoproj
                     package_affected_by_push_event(*info)
                 end
 
-                per_package.delete_if do |package, package_events|
-                    latest_event = package_events.max_by(&:created_at)
-                    package.head_sha == latest_event.head_sha
+                memo = {}
+                per_package.delete_if do |package, _|
+                    remote_sha = branch_current_head(
+                        package.owner, package.name, package.branch,
+                        memo: memo
+                    )
+                    !remote_sha || (package.head_sha == remote_sha)
                 end
 
                 per_package

--- a/lib/autoproj/daemon/overrides_retriever.rb
+++ b/lib/autoproj/daemon/overrides_retriever.rb
@@ -71,7 +71,7 @@ module Autoproj
                 nil
             end
 
-            # @param [Array<Github::PullRequest] visited
+            # @param [Array<Github::PullRequest>] visited
             # @param [Github::PullRequest] pull_request
             # @return [Boolean]
             def visited?(visited, pull_request)

--- a/lib/autoproj/daemon/pull_request_cache.rb
+++ b/lib/autoproj/daemon/pull_request_cache.rb
@@ -70,6 +70,10 @@ module Autoproj
                 pull_requests.find { |pr| pr.caches_pull_request?(pull_request) }
             end
 
+            def include?(pull_request)
+                cached(pull_request)
+            end
+
             # @param [Github::PullRequest] pull_request
             # @return [Boolean]
             def changed?(pull_request, overrides)

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -40,7 +40,7 @@ module Autoproj
                         .new_instances
                         .should_receive("request").and_return(response)
 
-                    assert bb.build
+                    assert bb.post_change
                 end
                 it "returns false if command fails" do
                     ws.config.daemon_buildbot_host = "bb-master"
@@ -54,7 +54,7 @@ module Autoproj
                         .should_receive("request")
                         .and_return(response)
 
-                    refute bb.build
+                    refute bb.post_change
                 end
                 it "returns false if the request fails because of network errors" do
                     ws.config.daemon_buildbot_host = "bb-master"
@@ -65,13 +65,13 @@ module Autoproj
                         .should_receive("request")
                         .and_raise(Errno::ECONNREFUSED)
 
-                    refute bb.build
+                    refute bb.post_change
                 end
             end
-            describe "#build_pull_request" do
+            describe "#post_pull_request_changes" do
                 it "adds buildbot force build paramaters" do
                     now = Time.now
-                    flexmock(bb).should_receive(:build).with(
+                    flexmock(bb).should_receive(:post_change).with(
                         author: "contributor",
                         branch: "autoproj/wetpaint/tidewise/drivers-gps_ublox/pulls/22",
                         category: "pull_request",
@@ -95,13 +95,13 @@ module Autoproj
                         updated_at: now
                     )
 
-                    bb.build_pull_request(pr)
+                    bb.post_pull_request_changes(pr)
                 end
             end
-            describe "#build_mainline_push_event" do
+            describe "#post_mainline_changes" do
                 it "adds buildbot force build paramaters" do
                     now = Time.now
-                    flexmock(bb).should_receive(:build).with(
+                    flexmock(bb).should_receive(:post_change).with(
                         author: "g-arjones",
                         branch: "master",
                         category: "push",
@@ -122,7 +122,7 @@ module Autoproj
                         created_at: now
                     )
 
-                    bb.build_mainline_push_event(event)
+                    bb.post_mainline_changes(flexmock, [event])
                 end
             end
         end

--- a/test/autoproj/daemon/test_buildconf_manager.rb
+++ b/test/autoproj/daemon/test_buildconf_manager.rb
@@ -284,7 +284,7 @@ module Autoproj
                     @manager.update_pull_requests
 
                     flexmock(@manager).should_receive(:commit_and_push_overrides).never
-                    flexmock(@manager.bb).should_receive(:build).never
+                    flexmock(@manager.bb).should_receive(:post_change).never
                     @manager.trigger_build_if_branch_changed([branch])
                 end
                 it "triggers if overrides changed" do
@@ -325,7 +325,7 @@ module Autoproj
 
                     flexmock(@manager).should_receive(:commit_and_push_overrides)
                                       .with(branch_name, expected_overrides).once
-                    flexmock(@manager.bb).should_receive(:build_pull_request)
+                    flexmock(@manager.bb).should_receive(:post_pull_request_changes)
                                          .with(pr).once
 
                     @manager.trigger_build_if_branch_changed([branch])
@@ -377,7 +377,7 @@ module Autoproj
                     branch_name = "autoproj/myproject/"\
                                   "rock-core/drivers-iodrivers_base/pulls/12"
 
-                    flexmock(@manager.bb).should_receive(:build_pull_request)
+                    flexmock(@manager.bb).should_receive(:post_pull_request_changes)
                                          .with(pr).once
                     flexmock(@manager).should_receive(:commit_and_push_overrides)
                                       .with(branch_name, overrides).once
@@ -431,7 +431,7 @@ module Autoproj
 
                     branch_name = "autoproj/myproject/"\
                                   "rock-core/drivers-iodrivers_base/pulls/12"
-                    flexmock(@manager.bb).should_receive(:build_pull_request)
+                    flexmock(@manager.bb).should_receive(:post_pull_request_changes)
                                          .with(pr).once
                     flexmock(@manager).should_receive(:commit_and_push_overrides)
                                       .with(branch_name, overrides).once

--- a/test/autoproj/daemon/test_github_watcher.rb
+++ b/test/autoproj/daemon/test_github_watcher.rb
@@ -23,7 +23,7 @@ module Autoproj
                 )
 
                 @ws.config.daemon_polling_period = 0
-                @packages = []
+                @packages = [autoproj_daemon_buildconf_package]
 
                 @client = Github::Client.new
                 @cache = PullRequestCache.new(@ws)
@@ -47,7 +47,8 @@ module Autoproj
                 )
 
                 @packages << PackageRepository.new(
-                    pkg_name, owner, name, pkg.vcs.to_hash, ws: ws, local_dir: pkg.srcdir
+                    pkg_name, owner, name, pkg.vcs.to_hash,
+                    ws: ws, local_dir: pkg.srcdir
                 )
 
                 @packages.last
@@ -160,27 +161,20 @@ module Autoproj
                     )
                 end
                 it "returns the cached pull request that is affected by a push" do
-                    event = autoproj_daemon_add_push_event(
-                        owner: "contributor",
-                        name: "tools-syskit_fork",
-                        branch: "feature",
-                        created_at: Time.now
+                    pr = watcher.cached_pull_request_affected_by_push_event(
+                        "contributor", "tools-syskit_fork", "feature"
                     )
-                    assert_equal @cached,
-                                 watcher.cached_pull_request_affected_by_push_event(event)
+                    assert_equal @cached, pr
                 end
                 it "returns nil if the event does not affect any pull request" do
-                    event = autoproj_daemon_add_push_event(
-                        owner: "contributor",
-                        name: "tools-roby",
-                        branch: "feature",
-                        created_at: Time.now
+                    pr = watcher.cached_pull_request_affected_by_push_event(
+                        "contributor", "tools-roby", "feature"
                     )
-                    assert_nil watcher.cached_pull_request_affected_by_push_event(event)
+                    assert_nil pr
                 end
             end
 
-            describe "#filter_events" do
+            describe "#partition_and_filter_events" do
                 before do
                     @events = []
                     @events << autoproj_daemon_add_push_event(
@@ -203,7 +197,7 @@ module Autoproj
                     add_package("drivers/gps_ublox", "tidewise", "drivers-gps_ublox",
                                 "feature")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events).all_events
                     assert_equal 2, events.size
                     assert_equal events.first, @events[0]
                     assert_equal events.last, @events[1]
@@ -216,7 +210,7 @@ module Autoproj
                         created_at: Time.new(1990, 1, 1)
                     )
                     add_package("tools/roby", "rock-core", "tools-roby")
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events).all_events
 
                     assert_equal 0, events.size
                 end
@@ -224,7 +218,8 @@ module Autoproj
                     add_package("drivers/gps_ublox", "tidewise", "drivers-gps_ublox",
                                 "feature")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
+                                    .pull_request_events
                     assert_equal 1, events.size
                     assert_equal events.first, @events.last
                 end
@@ -232,7 +227,8 @@ module Autoproj
                     add_package("drivers/iodrivers_base",
                                 "rock-core", "drivers-iodrivers_base")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
+                                    .push_events_to_mainline
                     assert_equal 1, events.size
                     assert_equal events.first, @events.first
                 end
@@ -263,125 +259,84 @@ module Autoproj
                         ]
                     )
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
+                                    .push_events_to_pull_request
                     assert_equal 1, events.size
                     assert_equal events.first, @events.last
                 end
-                it "removes pushes if branches are different" do
+                it "removes pull request pushes if the base branch is not our mainline" do
                     add_package("drivers/iodrivers_base",
                                 "rock-core", "drivers-iodrivers_base", "develop")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
                 it "removes pushes if owners are different" do
                     add_package("drivers/iodrivers_base",
                                 "tidewise", "drivers-iodrivers_base")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
                 it "removes pushes if names are different" do
                     add_package("drivers/iodrivers_base",
                                 "rock-core", "drivers-iodrivers_base2")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
-                it "removes pull requests if branches are different" do
+                it "removes pull request events if branches are different" do
                     add_package("drivers/gps_ublox", "tidewise", "drivers-gps_ublox")
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
                 it "removes pull requests if owners are different" do
                     add_package("drivers/gps_ublox", "rock-core", "drivers-gps_ublox",
                                 "feature")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
                 it "removes pull requests if names are different" do
                     add_package("drivers/gps_ublox", "tidewise", "drivers-gps_ublox2",
                                 "feature")
 
-                    events = watcher.filter_events(@events)
+                    events = watcher.partition_and_filter_events(@events)
                     assert events.empty?
                 end
             end
 
-            describe "#package_affected_by_push_event?" do
+            describe "#package_affected_by_push_event" do
                 before do
                     @pkg = add_package("drivers/gps_base", "rock-core",
                                        "drivers-gps_base", "master")
                 end
                 it "returns a package definition that is the target of a push event" do
-                    event = autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_base",
-                        branch: "master",
-                        created_at: Time.now
+                    package = watcher.package_affected_by_push_event(
+                        "rock-core", "drivers-gps_base", "master"
                     )
-
-                    assert_equal @pkg, watcher.package_affected_by_push_event(event)
+                    assert_equal @pkg, package
                 end
                 it "returns nil if the push target is an untracked repository" do
-                    event = autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-iodrivers_base",
-                        branch: "master",
-                        created_at: Time.now
+                    package = watcher.package_affected_by_push_event(
+                        "rock-core", "drivers-iodrivers_base", "master"
                     )
-
-                    assert_nil watcher.package_affected_by_push_event(event)
+                    assert_nil package
+                end
+                it "handles the build configuration itself" do
+                    package = watcher.package_affected_by_push_event(
+                        "rock-core", "buildconf", "master"
+                    )
+                    assert_equal autoproj_daemon_buildconf_package, package
                 end
             end
 
-            describe "#dispatch_push_event" do
+            describe "#process_modified_pull_requests" do
                 before do
                     @pkg = add_package("drivers/gps_base", "rock-core",
                                        "drivers-gps_base", "master")
-                end
-                it "calls push hooks if a mainline push has a different head" do
-                    event = autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_base",
-                        branch: "master",
-                        head_sha: "eghijk",
-                        created_at: Time.now
-                    )
 
-                    handler = flexmock
-                    handler.should_receive(:handle).with(event, mainline: true,
-                                                                pull_request: nil).once
-
-                    watcher.add_push_hook do |push_event, **options|
-                        handler.handle(push_event, options)
-                    end
-
-                    watcher.dispatch_push_event(event)
-                end
-                it "do not call push hooks if the mainline push has the same head" do
-                    pkg = @packages.find { |p| p.package == "drivers/gps_base" }
-                    event = autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_base",
-                        branch: "master",
-                        head_sha: pkg.head_sha,
-                        created_at: Time.now
-                    )
-
-                    handler = flexmock
-                    handler.should_receive(:handle).with(event, mainline: true,
-                                                                pull_request: nil).never
-
-                    watcher.add_push_hook do |push_event, **options|
-                        handler.handle(push_event, options)
-                    end
-
-                    watcher.dispatch_push_event(event)
-                end
-                it "calls push hooks if push is to an open pull request" do
-                    pr = autoproj_daemon_add_pull_request(
+                    @pr = autoproj_daemon_add_pull_request(
                         base_owner: "rock-core",
                         base_name: "drivers-gps_base",
                         number: 1,
@@ -392,7 +347,9 @@ module Autoproj
                         head_sha: "eghijk",
                         state: "open"
                     )
+                end
 
+                it "returns the pull requests for the push events" do
                     event = autoproj_daemon_add_push_event(
                         owner: "contributor",
                         name: "drivers-gps_base",
@@ -400,39 +357,28 @@ module Autoproj
                         head_sha: "eghijk",
                         created_at: Time.now + 2
                     )
-
-                    @cache.add(
-                        pr,
-                        [
-                            "drivers-gps_base" => {
-                                "remote_branch" => "refs/pull/1/merge"
-                            }
-                        ]
-                    )
-
-                    handler = flexmock
-                    handler.should_receive(:handle).with(event, mainline: false,
-                                                                pull_request: pr).once
-
-                    watcher.add_push_hook do |push_event, **options|
-                        handler.handle(push_event, options)
-                    end
-
-                    watcher.dispatch_push_event(event)
+                    events = GithubWatcher::PartitionedEvents.new([], [event], [])
+                    @cache.add(@pr, [])
+                    pull_requests = watcher.process_modified_pull_requests(events)
+                    assert_equal({ @pr => [event] }, pull_requests)
                 end
-                it "does not call push hooks if push is to a closed pull request" do
-                    pr = autoproj_daemon_add_pull_request(
+
+                it "returns the pull requests for the pull request events" do
+                    event = autoproj_daemon_add_pull_request_event(
                         base_owner: "rock-core",
                         base_name: "drivers-gps_base",
-                        number: 1,
                         base_branch: "master",
-                        head_owner: "contributor",
-                        head_name: "drivers-gps_base",
-                        head_branch: "feature",
-                        head_sha: "eghijk",
-                        state: "closed"
+                        state: "open",
+                        number: 1,
+                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
                     )
+                    events = GithubWatcher::PartitionedEvents.new([], [], [event])
+                    @cache.add(@pr, [])
+                    pull_requests = watcher.process_modified_pull_requests(events)
+                    assert_equal({ @pr => [event] }, pull_requests)
+                end
 
+                it "ignores push events whose pull request is not yet in cache" do
                     event = autoproj_daemon_add_push_event(
                         owner: "contributor",
                         name: "drivers-gps_base",
@@ -440,88 +386,117 @@ module Autoproj
                         head_sha: "eghijk",
                         created_at: Time.now + 2
                     )
-
-                    @cache.add(
-                        pr,
-                        [
-                            "drivers-gps_base" => {
-                                "remote_branch" => "refs/pull/1/merge"
-                            }
-                        ]
-                    )
-
-                    handler = flexmock
-                    handler.should_receive(:handle).with(event, mainline: false,
-                                                                pull_request: pr).never
-
-                    watcher.add_push_hook do |push_event, **options|
-                        handler.handle(push_event, options)
-                    end
-
-                    watcher.dispatch_push_event(event)
+                    events = GithubWatcher::PartitionedEvents.new([], [event], [])
+                    pull_requests = watcher.process_modified_pull_requests(events)
+                    assert_equal({}, pull_requests)
                 end
-                it "does not call push hooks if push is to a PR that no longer exists" do
-                    pr = autoproj_daemon_add_pull_request(
+
+                it "returns a given pull request only once" do
+                    e0 = autoproj_daemon_add_push_event(
+                        owner: "contributor",
+                        name: "drivers-gps_base",
+                        branch: "feature",
+                        head_sha: "eghijk",
+                        created_at: Time.now + 2
+                    )
+                    e1 = autoproj_daemon_add_pull_request_event(
                         base_owner: "rock-core",
                         base_name: "drivers-gps_base",
-                        number: 1,
                         base_branch: "master",
-                        head_owner: "contributor",
-                        head_name: "drivers-gps_base",
-                        head_branch: "feature",
-                        head_sha: "eghijk",
-                        state: "closed"
+                        state: "open",
+                        number: 1,
+                        created_at: Time.now + 3
                     )
+                    events = GithubWatcher::PartitionedEvents.new([], [e0], [e1])
+                    @cache.add(@pr, [])
+                    pull_requests = watcher.process_modified_pull_requests(events)
+                    assert_equal({ @pr => [e0, e1] }, pull_requests)
+                end
+            end
 
+            describe "#process_modified_mainlines" do
+                before do
+                    @pkg = add_package("drivers/gps_base", "rock-core",
+                                       "drivers-gps_base", "master")
+                end
+
+                it "returns the affected packages" do
                     event = autoproj_daemon_add_push_event(
-                        owner: "contributor",
+                        owner: "rock-core",
                         name: "drivers-gps_base",
-                        branch: "feature",
+                        branch: "master",
+                        head_sha: "efohai",
+                        created_at: Time.now
+                    )
+
+                    events = GithubWatcher::PartitionedEvents.new([event], [], [])
+                    packages = watcher.process_modified_mainlines(events)
+                    assert_equal({ @pkg => [event] }, packages)
+                end
+
+                it "returns nothing if the latest event's SHA matches the package's" do
+                    e0 = autoproj_daemon_add_push_event(
+                        owner: "rock-core",
+                        name: "drivers-gps_base",
+                        branch: "master",
+                        head_sha: "efohai",
+                        created_at: Time.now - 1
+                    )
+                    e1 = autoproj_daemon_add_push_event(
+                        owner: "rock-core",
+                        name: "drivers-gps_base",
+                        branch: "master",
+                        head_sha: @pkg.head_sha,
+                        created_at: Time.now
+                    )
+
+                    events = GithubWatcher::PartitionedEvents.new([e0, e1], [], [])
+                    packages = watcher.process_modified_mainlines(events)
+                    assert packages.empty?
+                end
+
+                it "returns a package only once" do
+                    event0 = autoproj_daemon_add_push_event(
+                        owner: "rock-core",
+                        name: "drivers-gps_base",
+                        branch: "master",
                         head_sha: "eghijk",
-                        created_at: Time.now + 2
+                        created_at: Time.now
+                    )
+                    event1 = autoproj_daemon_add_push_event(
+                        owner: "rock-core",
+                        name: "drivers-gps_base",
+                        branch: "master",
+                        head_sha: "egedrohigf",
+                        created_at: (Time.now + 1)
                     )
 
-                    @cache.add(
-                        pr,
-                        [
-                            "drivers-gps_base" => {
-                                "remote_branch" => "feature"
-                            }
-                        ]
+                    events = GithubWatcher::PartitionedEvents.new(
+                        [event0, event1], [], []
                     )
-
-                    handler = flexmock
-                    handler.should_receive(:handle).with(event, mainline: false,
-                                                                pull_request: pr).never
-
-                    watcher.add_push_hook do |push_event, **options|
-                        handler.handle(push_event, options)
-                    end
-
-                    watcher.dispatch_push_event(event)
+                    packages = watcher.process_modified_mainlines(events)
+                    assert_equal({ @pkg => [event0, event1] }, packages)
                 end
             end
 
             describe "#handle_owner_events" do
-                before do
-                    @events = []
-                end
-                it "calls the right handler for the kind of event" do
-                    @events << autoproj_daemon_add_push_event(
+                it "partitions events, resolves packages and PRs and forwards them" do
+                    events = []
+                    events << autoproj_daemon_add_push_event(
                         owner: "rock-core",
                         name: "drivers-gps_ublox",
                         branch: "master",
                         head_sha: "1234",
                         created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
                     )
-                    @events << autoproj_daemon_add_push_event(
+                    events << autoproj_daemon_add_push_event(
                         owner: "rock-core",
                         name: "drivers-gps_ublox",
                         branch: "master",
                         head_sha: "abcd",
                         created_at: Time.utc(2019, "sep", 22, 23, 53, 40)
                     )
-                    @events << autoproj_daemon_add_pull_request_event(
+                    events << autoproj_daemon_add_pull_request_event(
                         base_owner: "rock-core",
                         base_name: "drivers-gps_ublox",
                         base_branch: "master",
@@ -529,7 +504,7 @@ module Autoproj
                         number: 1,
                         created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
                     )
-                    @events << autoproj_daemon_add_pull_request_event(
+                    events << autoproj_daemon_add_pull_request_event(
                         base_owner: "rock-core",
                         base_name: "drivers-gps_ublox",
                         base_branch: "master",
@@ -542,232 +517,30 @@ module Autoproj
                         "rock-core", "drivers-gps_ublox",
                         branch_name: "master", sha: "abcd"
                     )
-                    autoproj_daemon_add_pull_request(
+                    pr0 = autoproj_daemon_add_pull_request(
                         base_owner: "rock-core", base_name: "drivers-gps_ublox",
                         base_branch: "master", number: 1, sha: "abcd"
                     )
-                    autoproj_daemon_add_pull_request(
+                    pr1 = autoproj_daemon_add_pull_request(
                         base_owner: "rock-core", base_name: "drivers-gps_ublox",
                         base_branch: "master", number: 2, sha: "abcd"
                     )
-                    add_package("drivers/gps_ublox", "rock-core", "drivers-gps_ublox")
-                    @events[2..3].each { |event| @cache.add(event.pull_request, []) }
-
-                    flexmock(watcher)
-
-                    watcher.should_receive(:dispatch_push_event)
-                           .with(@events[1]).once
-                    watcher.should_receive(:call_pull_request_hooks)
-                           .with(@events[2]).once
-                    watcher.should_receive(:call_pull_request_hooks)
-                           .with(@events[3]).once
-
-                    watcher.handle_owner_events("rock-core", @events)
-                end
-                it "ignores events on third-party repos" do
-                    @events << autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_ublox",
-                        branch: "master",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
+                    pkg = add_package(
+                        "drivers/gps_ublox", "rock-core", "drivers-gps_ublox"
                     )
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_ublox",
-                        base_branch: "master",
-                        state: "open",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
+                    events[2..3].each { |event| @cache.add(event.pull_request, []) }
 
-                    add_package("drivers/gps_ublox", "rock-core", "drivers-gps_ublox")
-                    @cache.add(@events[1].pull_request, [])
+                    received_packages, received_pull_requests = nil
+                    watcher.subscribe do |packages, pull_requests|
+                        received_packages = packages
+                        received_pull_requests = pull_requests
+                    end
 
-                    flexmock(watcher)
-                        .should_receive(:handle_push_events)
-                        .with([]).once
+                    watcher.handle_owner_events("rock-core", events)
 
-                    flexmock(watcher)
-                        .should_receive(:handle_pull_request_events)
-                        .with([]).once
-
-                    watcher.handle_owner_events("tidewise", @events)
-                end
-                it "updates the event's SHA using the current branch state" do
-                    ev = autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_ublox",
-                        branch: "master",
-                        head_sha: "1234",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    @events << ev
-                    autoproj_daemon_add_branch(
-                        "rock-core", "drivers-gps_ublox",
-                        branch_name: "master", sha: "3456"
-                    )
-
-                    add_package("drivers/gps_ublox", "rock-core", "drivers-gps_ublox")
-
-                    expected_ev = ev.dup
-                    expected_ev.head_sha = "3456"
-                    flexmock(watcher)
-                        .should_receive(:handle_push_events)
-                        .with([expected_ev]).once
-
-                    watcher.handle_owner_events("rock-core", @events)
-                end
-            end
-
-            describe "#handle_push_events" do
-                before do
-                    @events = []
-                end
-                it "synthetizes push events containing the latest HEAD" do
-                    @events << autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_ublox",
-                        branch: "master",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    @events << autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_ublox",
-                        branch: "master",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 40)
-                    )
-                    @events << autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_base",
-                        branch: "master",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 45)
-                    )
-                    @events << autoproj_daemon_add_push_event(
-                        owner: "rock-core",
-                        name: "drivers-gps_base",
-                        branch: "master",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 50)
-                    )
-
-                    autoproj_daemon_add_branch(
-                        "rock-core", "drivers-gps_base",
-                        branch_name: "master", sha: "1234"
-                    )
-                    autoproj_daemon_add_branch(
-                        "rock-core", "drivers-gps_ublox",
-                        branch_name: "master", sha: "abcd"
-                    )
-                    expected_master = @events[1].dup
-                    expected_master.head_sha = "1234"
-                    expected_base = @events[3].dup
-                    expected_base.head_sha = "abcd"
-
-                    flexmock(watcher)
-                    watcher.should_receive(:dispatch_push_event)
-                           .with(expected_master).once
-                    watcher.should_receive(:dispatch_push_event)
-                           .with(expected_base).once
-                    watcher.handle_push_events(@events)
-                end
-            end
-            describe "#handle_pull_request_events" do
-                before do
-                    @events = []
-                end
-                it "synthetizes pull request event from the actual PR states" do
-                    # Register PR#2 in the cache
-                    pr2_open_event = autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_base",
-                        base_branch: "master",
-                        number: 2,
-                        state: "open",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 20)
-                    )
-                    @cache.add(pr2_open_event.pull_request, {})
-
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_ublox",
-                        base_branch: "master",
-                        number: 1,
-                        state: "open",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_ublox",
-                        base_branch: "master",
-                        number: 1,
-                        state: "closed",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 40)
-                    )
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_base",
-                        number: 2,
-                        base_branch: "master",
-                        state: "closed",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_base",
-                        base_branch: "master",
-                        number: 2,
-                        state: "open",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 40)
-                    )
-
-                    autoproj_daemon_add_pull_request(
-                        base_owner: "rock-core", base_name: "drivers-gps_ublox",
-                        base_branch: "master", number: 1, state: "open"
-                    )
-                    autoproj_daemon_add_pull_request(
-                        base_owner: "rock-core", base_name: "drivers-gps_ublox",
-                        base_branch: "master", number: 2, state: "closed"
-                    )
-
-                    expected_pr1 = @events[1].dup
-                    expected_pr1.pull_request.open = true
-                    expected_pr2 = @events[3].dup
-                    expected_pr2.pull_request.open = false
-
-                    flexmock(watcher)
-                    watcher.should_receive(:call_pull_request_hooks)
-                           .with(expected_pr1).once
-                    watcher.should_receive(:call_pull_request_hooks)
-                           .with(expected_pr2).once
-                    watcher.handle_pull_request_events(@events)
-                end
-                it "handles close events of cached PRs" do
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_ublox",
-                        base_branch: "master",
-                        number: 1,
-                        state: "closed",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    @cache.add(@events[0].pull_request, [])
-
-                    flexmock(watcher).should_receive(:call_pull_request_hooks)
-                                     .with(@events[0]).once
-
-                    watcher.handle_pull_request_events(@events)
-                end
-                it "ignores close events of unknown PRs" do
-                    @events << autoproj_daemon_add_pull_request_event(
-                        base_owner: "rock-core",
-                        base_name: "drivers-gps_ublox",
-                        base_branch: "master",
-                        number: 1,
-                        state: "closed",
-                        created_at: Time.utc(2019, "sep", 22, 23, 53, 35)
-                    )
-                    flexmock(watcher).should_receive(:call_pull_request_hooks)
-                                     .with(@events[0]).never
-
-                    watcher.handle_pull_request_events(@events)
+                    assert_equal({ pkg => events[0, 2] }, received_packages)
+                    assert_equal({ pr0 => [events[2]], pr1 => [events[3]] },
+                                 received_pull_requests)
                 end
             end
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -211,7 +211,7 @@ module Autoproj
             end
 
             def autoproj_daemon_add_push_event(**options)
-                event = Autoproj::Daemon::Github::PushEvent.new(
+                event = Autoproj::Daemon::Github::PushEvent.from_ruby_hash(
                     repo: {
                         name: "#{options[:owner]}/#{options[:name]}"
                     },
@@ -230,7 +230,7 @@ module Autoproj
             end
 
             def autoproj_daemon_create_pull_request(options)
-                Autoproj::Daemon::Github::PullRequest.new(
+                Autoproj::Daemon::Github::PullRequest.from_ruby_hash(
                     state: options[:state],
                     number: options[:number],
                     title: options[:title],
@@ -267,7 +267,7 @@ module Autoproj
                     state: options[:state],
                     number: options[:number]
                 )
-                event = Autoproj::Daemon::Github::PullRequestEvent.new(
+                event = Autoproj::Daemon::Github::PullRequestEvent.from_ruby_hash(
                     payload: {
                         pull_request: pr.instance_variable_get(:@model)
                     },
@@ -279,7 +279,7 @@ module Autoproj
             end
 
             def autoproj_daemon_add_pull_request(**options)
-                pr = Autoproj::Daemon::Github::PullRequest.new(
+                pr = Autoproj::Daemon::Github::PullRequest.from_ruby_hash(
                     state: options[:state],
                     number: options[:number],
                     title: options[:title],
@@ -312,7 +312,7 @@ module Autoproj
             end
 
             def autoproj_daemon_add_branch(owner, name, options)
-                branch = Autoproj::Daemon::Github::Branch.new(
+                branch = Autoproj::Daemon::Github::Branch.from_ruby_hash(
                     owner, name,
                     name: options[:branch_name],
                     commit: {


### PR DESCRIPTION
Closes #39 
Replaces #41 

In the current architecture, the events were passed to the buildconf
manager for processing. This led to a lot of little bugs with major
impact (usually, build loops).

This refactors the interaction between the watcher and the buildconf
manager to only pass the objects that might have changed (inferred
from the events), freshly taken from GitHub itself. Working with
the full state is a lot easier on both sides.