### PR TITLE
fix: better handle errors during the update process

### DIFF
--- a/lib/autoproj/daemon/git_poller.rb
+++ b/lib/autoproj/daemon/git_poller.rb
@@ -93,12 +93,18 @@ module Autoproj
                 Autoproj.message "Fetching branches from "\
                     "#{filtered_repos.size} repositories..."
 
-                @package_branches = filtered_repos.flat_map do |pkg|
+                package_branches = filtered_repos.flat_map do |pkg|
                     client.branch(pkg.repo_url, pkg.branch)
+                rescue StandardError => e
+                    Autoproj.warn "could not fetch information about #{pkg.package} "\
+                                  "from #{pkg.repo_url}, branch #{pkg.branch}"
+                    Autoproj.warn "ignoring this package until this gets resolved"
+                    Autoproj.warn e.message
+                    nil
                 end
 
                 Autoproj.message "Tracking #{package_branches.size} branches"
-                package_branches
+                @package_branches = package_branches.compact
             end
 
             # @param [GitAPI::Branch] branch

--- a/test/autoproj/daemon/test_git_poller.rb
+++ b/test/autoproj/daemon/test_git_poller.rb
@@ -873,6 +873,24 @@ module Autoproj
                     refute_nil @poller.cache.cached(pr)
                 end
             end
+
+            describe "#poll" do
+                it "restarts the daemon if anything raises" do
+                    flexmock(@poller.updater)
+                        .should_receive(:update_failed?).and_raise(RuntimeError)
+                    flexmock(@poller.updater)
+                        .should_receive(:restart_and_update).once
+                    @poller.poll
+                end
+
+                it "does not catch SIGINT" do
+                    flexmock(@poller.updater)
+                        .should_receive(:update_failed?).and_raise(Interrupt)
+                    assert_raises(Interrupt) do
+                        @poller.poll
+                    end
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
What triggered this work was the merge of a branch that was currently the mainline of a
package. This caused the daemon to quit (update_package_branches would raise), and
updating the mainline would not fix the problem since we called update_package_branches
first.