### PR TITLE
Fix gitlab status reporting

### DIFF
--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -110,9 +110,9 @@ module Autoproj
                 request = Net::HTTP::Post.new(uri.request_uri)
 
                 properties = {
-                    source_branch: source_branch
-                }
-                properties[:source_project_id] = source_project_id if source_project_id
+                    source_branch: source_branch,
+                    source_project_id: source_project_id
+                }.compact
 
                 options = {
                     author: author,

--- a/lib/autoproj/daemon/git_api/pull_request.rb
+++ b/lib/autoproj/daemon/git_api/pull_request.rb
@@ -41,6 +41,11 @@ module Autoproj
                     @model["head"]["sha"]
                 end
 
+                # @return [Integer]
+                def head_repo_id
+                    Integer(@model["head"]["repo"]["id"])
+                end
+
                 # @return [Time]
                 def updated_at
                     Time.parse(@model["updated_at"])

--- a/lib/autoproj/daemon/git_api/pull_request.rb
+++ b/lib/autoproj/daemon/git_api/pull_request.rb
@@ -32,6 +32,11 @@ module Autoproj
                 end
 
                 # @return [String]
+                def head_branch
+                    @model["head"]["ref"]
+                end
+
+                # @return [String]
                 def head_sha
                     @model["head"]["sha"]
                 end

--- a/lib/autoproj/daemon/git_api/services/gitlab.rb
+++ b/lib/autoproj/daemon/git_api/services/gitlab.rb
@@ -50,6 +50,7 @@ module Autoproj
 
                     # @param [Gitlab::ObjectifiedHash] mrequest
                     # @return [Hash]
+                    # rubocop: disable Metrics/AbcSize
                     def merge_request_to_ruby_hash(git_url, mrequest)
                         state = mrequest.state == "opened" ? "open" : mrequest.state.to_s
                         {
@@ -73,12 +74,16 @@ module Autoproj
                             head: {
                                 ref: mrequest.source_branch,
                                 sha: mrequest.sha,
+                                repo: {
+                                    id: mrequest.source_project_id
+                                },
                                 user: {
                                     login: ""
                                 }
                             }
                         }
                     end
+                    # rubocop: enable Metrics/AbcSize
 
                     # @param [Gitlab::ObjectifiedHash] branch
                     # @return [Hash]

--- a/lib/autoproj/daemon/git_poller.rb
+++ b/lib/autoproj/daemon/git_poller.rb
@@ -139,7 +139,8 @@ module Autoproj
                                              "workspace, and will trigger a new build "\
                                              "if that's successful"
                         else
-                            bb.post_mainline_changes(pkg, branch)
+                            bb.post_mainline_changes(pkg, branch,
+                                                     buildconf_branch: buildconf.branch)
                         end
                         changed = true
                     end
@@ -157,7 +158,8 @@ module Autoproj
                     "Push detected on the buildconf: local: #{buildconf.head_sha}, "\
                     "remote: #{buildconf_branch.sha}"
                 )
-                bb.post_mainline_changes(buildconf, buildconf_branch)
+                bb.post_mainline_changes(buildconf, buildconf_branch,
+                                         buildconf_branch: buildconf_branch.branch_name)
                 true
             end
 

--- a/lib/autoproj/daemon/git_poller.rb
+++ b/lib/autoproj/daemon/git_poller.rb
@@ -350,7 +350,7 @@ module Autoproj
                 all_prs.flat_map do |pr|
                     packages_affected_by_pull_request(pr).map do |pkg|
                         key = if pkg.package_set?
-                                  "pkg_set:#{pkg.vcs[:repository_id]}"
+                                  "pkg_set:#{pkg.overrides_key}"
                               else
                                   pkg.package
                               end

--- a/lib/autoproj/daemon/package_repository.rb
+++ b/lib/autoproj/daemon/package_repository.rb
@@ -46,6 +46,11 @@ module Autoproj
             end
 
             # @return [String]
+            def overrides_key
+                Autoproj::VCSDefinition.from_raw(vcs).overrides_key
+            end
+
+            # @return [String]
             def branch
                 explicit_branch = vcs[:remote_branch] || vcs[:branch]
                 return explicit_branch if explicit_branch

--- a/test/autoproj/daemon/git_api/services/test_github.rb
+++ b/test/autoproj/daemon/git_api/services/test_github.rb
@@ -242,6 +242,11 @@ module Autoproj
                             assert_equal "master", pull_request.base_branch
                         end
 
+                        it "returns the head branch" do
+                            pull_request = client.pull_requests(url).first
+                            assert_equal "saveAllAndCommitFix", pull_request.head_branch
+                        end
+
                         it "returns the head sha" do
                             pull_request = client.pull_requests(url).first
                             assert_equal "6a0c40a0cc4edd4b5c9e520be86ac0c5c4402dd9",

--- a/test/autoproj/daemon/git_api/services/test_github.rb
+++ b/test/autoproj/daemon/git_api/services/test_github.rb
@@ -247,6 +247,11 @@ module Autoproj
                             assert_equal "saveAllAndCommitFix", pull_request.head_branch
                         end
 
+                        it "returns the head repo id" do
+                            pull_request = client.pull_requests(url).first
+                            assert_equal 166_283_792, pull_request.head_repo_id
+                        end
+
                         it "returns the head sha" do
                             pull_request = client.pull_requests(url).first
                             assert_equal "6a0c40a0cc4edd4b5c9e520be86ac0c5c4402dd9",

--- a/test/autoproj/daemon/git_api/services/test_gitlab.rb
+++ b/test/autoproj/daemon/git_api/services/test_gitlab.rb
@@ -215,6 +215,11 @@ module Autoproj
                         assert_equal "test1", pull_request.head_branch
                     end
 
+                    it "returns the head repo id" do
+                        pull_request = client.pull_requests(url).first
+                        assert_equal 2, pull_request.head_repo_id
+                    end
+
                     it "returns the head sha" do
                         pull_request = client.pull_requests(url).first
                         assert_equal "8888888888888888888888888888888888888888",

--- a/test/autoproj/daemon/git_api/services/test_gitlab.rb
+++ b/test/autoproj/daemon/git_api/services/test_gitlab.rb
@@ -210,6 +210,11 @@ module Autoproj
                         assert_equal "master", pull_request.base_branch
                     end
 
+                    it "returns the head branch" do
+                        pull_request = client.pull_requests(url).first
+                        assert_equal "test1", pull_request.head_branch
+                    end
+
                     it "returns the head sha" do
                         pull_request = client.pull_requests(url).first
                         assert_equal "8888888888888888888888888888888888888888",

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -75,9 +75,11 @@ module Autoproj
                         author: "author",
                         branch: "autoproj/wetpaint/github.com/"\
                                 "tidewise/drivers-gps_ublox/pulls/22",
+                        source_branch: "feature",
                         category: "pull_request",
                         codebase: "",
                         committer: "contributor",
+                        source_project_id: 10,
                         repository: "https://github.com/tidewise/drivers-gps_ublox",
                         revision: "abcdef",
                         revlink: "https://github.com/tidewise/drivers-gps_ublox/pull/22",
@@ -88,6 +90,8 @@ module Autoproj
                         repo_url: "git@github.com:tidewise/drivers-gps_ublox.git",
                         number: 22,
                         base_branch: "master",
+                        head_branch: "feature",
+                        head_repo_id: 10,
                         last_committer: "contributor",
                         author: "author",
                         head_sha: "abcdef",
@@ -102,7 +106,8 @@ module Autoproj
                     now = Time.now
                     flexmock(bb).should_receive(:post_change).with(
                         author: "g-arjones",
-                        branch: "devel",
+                        branch: "main",
+                        source_branch: "devel",
                         category: "push",
                         codebase: "",
                         committer: "g-arjones",
@@ -120,7 +125,7 @@ module Autoproj
                         commit_date: now
                     )
 
-                    bb.post_mainline_changes(flexmock, branch)
+                    bb.post_mainline_changes(flexmock, branch, buildconf_branch: "main")
                 end
             end
         end

--- a/test/autoproj/daemon/test_git_poller.rb
+++ b/test/autoproj/daemon/test_git_poller.rb
@@ -52,10 +52,10 @@ module Autoproj
                 package
             end
 
-            def expect_mainline_build(pkg, branch)
+            def expect_mainline_build(pkg, branch, buildconf_branch: nil)
                 flexmock(@poller.bb)
                     .should_receive(:post_mainline_changes)
-                    .with(pkg, branch)
+                    .with(pkg, branch, buildconf_branch: buildconf_branch)
                     .once
                     .ordered
             end
@@ -381,8 +381,12 @@ module Autoproj
                             sha: iodrivers_base3.head_sha
                         )
 
-                        expect_mainline_build(iodrivers_base, branches.first)
-                        expect_mainline_build(iodrivers_base2, branches.first)
+                        expect_mainline_build(iodrivers_base, branches.first,
+                                              buildconf_branch: @buildconf.branch)
+
+                        expect_mainline_build(iodrivers_base2, branches.first,
+                                              buildconf_branch: @buildconf.branch)
+
                         expect_no_mainline_build(iodrivers_base3, any)
                         expect_no_mainline_build(@buildconf, any)
                         expect_restart_and_update
@@ -400,7 +404,9 @@ module Autoproj
                             sha: "abcdef"
                         )
 
-                        expect_mainline_build(@buildconf, branch)
+                        expect_mainline_build(@buildconf, branch,
+                                              buildconf_branch: @buildconf.branch)
+
                         expect_restart_and_update
 
                         @poller.update_package_branches
@@ -424,7 +430,9 @@ module Autoproj
                         sha: "abcdef"
                     )
 
-                    expect_mainline_build(@buildconf, branch)
+                    expect_mainline_build(@buildconf, branch,
+                                          buildconf_branch: @buildconf.branch)
+
                     expect_restart_and_update
 
                     @cache.add(pull_request, [])
@@ -455,7 +463,7 @@ module Autoproj
                         sha: @buildconf.head_sha
                     )
 
-                    expect_mainline_build(pkg, branch)
+                    expect_mainline_build(pkg, branch, buildconf_branch: "master")
                     expect_no_mainline_build(@buildconf, any)
                     expect_restart_and_update
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -210,7 +210,11 @@ module Autoproj
                         }
                     },
                     head: {
+                        ref: options[:head_branch],
                         sha: options[:head_sha],
+                        repo: {
+                            id: options[:head_repo_id]
+                        },
                         user: {
                             login: options[:last_committer]
                         }


### PR DESCRIPTION
GitLab status reporting requires some additional properties to work properly (head branch and head repository id).

Also, the fact that we were using `remote_branch.branch_name` as buildbot's change `branch` property on mainline pushes to packages was a bug. The `branch` property is used to set the buildconf branch (which may be different from the package's mainline).