### PR TITLE
recover after spurious workspace update failure

### DIFF
--- a/lib/autoproj/daemon/workspace_updater.rb
+++ b/lib/autoproj/daemon/workspace_updater.rb
@@ -20,7 +20,7 @@ module Autoproj
 
             # Whether an attempt to update the workspace has failed
             #
-            # @return [Boolean]
+            # @return [Time]
             def update_failed?
                 @update_failed
             end
@@ -48,7 +48,7 @@ module Autoproj
                 # should do is update the workspace on push events,
                 # no PR syncing and no triggering of builds
                 # on PR events
-                @update_failed = true
+                @update_failed = Time.now
                 Autoproj.error e.message
                 false
             end


### PR DESCRIPTION
Add an extra safety net. 

Sometimes, an update may fail for spurious reasons (i.e internet connectivity issues). Waiting for a mainline push doesn't make much sense in such a scenario. Since this is a rare event, I've defined a relatively high update delay (while also watching for pushes that may eventually make us recover more quickly).