### PR TITLE
  feat: fix merge branch support on GitHub

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ inherit_mode:
   merge:
   - AllowedNames
 
+AllCops:
+  TargetRubyVersion: "2.5"
+
 Naming/MethodParameterName:
   AllowedNames:
   - ws

--- a/lib/autoproj/daemon/git_api/client.rb
+++ b/lib/autoproj/daemon/git_api/client.rb
@@ -207,7 +207,9 @@ module Autoproj
                 end
 
                 # @param [String] ref
-                # @param [GitAPI::PullRequest] pull_request
+                # @param [GitAPI::PullRequest] pull_request the pull request that
+                #   refers to `ref`, used to resolve which Git service we should
+                #   be using to resolve the reference if `ref` is not enough
                 # @return [String]
                 def extract_info_from_pull_request_ref(ref, pull_request)
                     begin
@@ -216,8 +218,7 @@ module Autoproj
                         url = pull_request.git_url.raw
                     end
 
-                    service(url)
-                        .extract_info_from_pull_request_ref(ref, pull_request)
+                    service(url).extract_info_from_pull_request_ref(ref, pull_request)
                 end
 
                 # @param [GitAPI::PullRequest] pull_request

--- a/lib/autoproj/daemon/git_api/json_facade.rb
+++ b/lib/autoproj/daemon/git_api/json_facade.rb
@@ -29,15 +29,15 @@ module Autoproj
                 end
 
                 def ==(other)
-                    @model == other.model
+                    @git_url == other.git_url && @model == other.model
                 end
 
                 def eql?(other)
-                    @model.eql?(other.model)
+                    @git_url.eql?(other.git_url) && @model.eql?(other.model)
                 end
 
                 def hash
-                    @model.hash
+                    [@git_url, @model].hash
                 end
 
                 def initialize_copy(_)

--- a/lib/autoproj/daemon/git_api/pull_request.rb
+++ b/lib/autoproj/daemon/git_api/pull_request.rb
@@ -32,6 +32,11 @@ module Autoproj
                 end
 
                 # @return [String]
+                def base_sha
+                    @model["base"]["sha"]
+                end
+
+                # @return [String]
                 def head_branch
                     @model["head"]["ref"]
                 end

--- a/lib/autoproj/daemon/git_api/pull_request.rb
+++ b/lib/autoproj/daemon/git_api/pull_request.rb
@@ -7,6 +7,12 @@ module Autoproj
         module GitAPI
             # A PullRequest model representation
             class PullRequest < JSONFacade
+                # List of dependencies resolved from the pull request body
+                #
+                # @return [Array<PullRequest>,nil] the dependencies, or nil if they
+                #   have not yet been computed
+                attr_accessor :dependencies
+
                 # @return [Boolean]
                 def open?
                     @model["state"] == "open"
@@ -89,6 +95,23 @@ module Autoproj
                 # @return [Boolean]
                 def mergeable?
                     @model["mergeable"]
+                end
+
+                # Resolve the list of recursive dependencies for this pull request
+                #
+                # @return [Set<GitAPI::PullRequest>]
+                def recursive_dependencies
+                    result = []
+                    queue = dependencies.dup
+                    until queue.empty?
+                        pr = queue.shift
+                        next if result.include?(pr)
+
+                        result << pr
+                        queue << pr
+                    end
+
+                    result
                 end
             end
         end

--- a/lib/autoproj/daemon/git_api/pull_request.rb
+++ b/lib/autoproj/daemon/git_api/pull_request.rb
@@ -105,10 +105,10 @@ module Autoproj
                     queue = dependencies.dup
                     until queue.empty?
                         pr = queue.shift
-                        next if result.include?(pr)
+                        next if result.include?(pr) || pr == self
 
                         result << pr
-                        queue << pr
+                        queue.concat(pr.dependencies)
                     end
 
                     result

--- a/lib/autoproj/daemon/git_api/services/github.rb
+++ b/lib/autoproj/daemon/git_api/services/github.rb
@@ -53,7 +53,9 @@ module Autoproj
                     def pull_requests(git_url, **options)
                         exception_adapter do
                             @client.pull_requests(git_url.path, **options).map do |pr|
-                                PullRequest.from_ruby_hash(git_url, pr.to_hash)
+                                mergeable = !pr["merged_at"] && pr["merge_commit_sha"]
+                                pr = { "mergeable" => mergeable }.merge(pr.to_hash)
+                                PullRequest.from_ruby_hash(git_url, pr)
                             end
                         end
                     end

--- a/lib/autoproj/daemon/git_api/services/github.rb
+++ b/lib/autoproj/daemon/git_api/services/github.rb
@@ -53,8 +53,8 @@ module Autoproj
                     )
                         super(**options)
 
-                        @client = create_octokit_client(cache: true)
-                        @client_nocache = create_octokit_client(cache: false)
+                        @client = create_octokit_client(cache: true, **options)
+                        @client_nocache = create_octokit_client(cache: false, **options)
 
                         @pr_commit_strategy = pr_commit_strategy
                         @mergeability_timeout = mergeability_timeout

--- a/lib/autoproj/daemon/git_api/services/github.rb
+++ b/lib/autoproj/daemon/git_api/services/github.rb
@@ -75,13 +75,7 @@ module Autoproj
                     def pull_requests(git_url, **options)
                         exception_adapter do
                             @client.pull_requests(git_url.path, **options).map do |pr|
-                                mergeable =
-                                    if pr["merged_at"]
-                                        false
-                                    else
-                                        pull_request_mergeable?(git_url, pr["number"])
-                                    end
-
+                                mergeable = pull_request_mergeable?(git_url, pr)
                                 pr = pr.to_hash.merge({ "mergeable" => mergeable })
                                 PullRequest.from_ruby_hash(git_url, pr)
                             end

--- a/lib/autoproj/daemon/git_api/services/github.rb
+++ b/lib/autoproj/daemon/git_api/services/github.rb
@@ -49,9 +49,6 @@ module Autoproj
                         super(**options)
 
                         stack = Faraday::RackBuilder.new do |builder|
-                            builder.use Faraday::HttpCache, serializer: Marshal,
-                                                            shared_cache: false
-
                             builder.use Octokit::Middleware::FollowRedirects
                             builder.use Octokit::Response::RaiseError
                             builder.adapter Faraday.default_adapter

--- a/lib/autoproj/extensions/configuration.rb
+++ b/lib/autoproj/extensions/configuration.rb
@@ -112,15 +112,16 @@ module Autoproj
                 **options
             )
                 host = sanitize_string(host).sub(/^www./, "")
-                options = {
+                options_from_args = {
                     "service" => sanitize_string(service),
                     "api_endpoint" => sanitize_string(api_endpoint),
                     "access_token" => access_token.to_s.strip
-                }.merge(options.transform_keys(&:to_s))
+                }
+                options_from_args.compact!
+                options_from_args.delete_if { |_, v| v.empty? }
 
-                options.compact!
-                options.delete_if { |_, v| v.empty? }
-
+                options = options_from_args
+                          .merge(options.transform_keys(&:to_s))
                 set(
                     "daemon_services",
                     daemon_services.merge({ host => options })

--- a/lib/autoproj/extensions/configuration.rb
+++ b/lib/autoproj/extensions/configuration.rb
@@ -108,14 +108,15 @@ module Autoproj
                 host,
                 access_token,
                 api_endpoint = nil,
-                service = nil
+                service = nil,
+                **options
             )
                 host = sanitize_string(host).sub(/^www./, "")
                 options = {
                     "service" => sanitize_string(service),
                     "api_endpoint" => sanitize_string(api_endpoint),
                     "access_token" => access_token.to_s.strip
-                }
+                }.merge(options.transform_keys(&:to_s))
 
                 options.compact!
                 options.delete_if { |_, v| v.empty? }

--- a/test/autoproj/daemon/git_api/services/github_pull_request.json
+++ b/test/autoproj/daemon/git_api/services/github_pull_request.json
@@ -332,6 +332,5 @@
       }
     },
     "author_association": "MEMBER",
-    "draft": false,
-    "mergeable": true
+    "draft": false
   }

--- a/test/autoproj/daemon/git_api/services/test_github.rb
+++ b/test/autoproj/daemon/git_api/services/test_github.rb
@@ -300,6 +300,28 @@ module Autoproj
                                          client.test_branch_name(pull_request)
                         end
 
+                        it "returns a non-mergeable PR if merged_at is not nil" do
+                            pr_model["merged_at"] = "something"
+                            pr_model["merge_commit_sha"] = "something"
+                            pull_request = client.pull_requests(url).first
+                            refute pull_request.mergeable?
+                        end
+
+                        it "returns a non-mergeable PR if merge_commit_sha is nil" do
+                            pr_model["merged_at"] = nil
+                            pr_model["merge_commit_sha"] = nil
+                            pull_request = client.pull_requests(url).first
+                            refute pull_request.mergeable?
+                        end
+
+                        it "returns a mergeable PR if merged_at is nil and "\
+                           "merge_commit_sha is not" do
+                            pr_model["merged_at"] = nil
+                            pr_model["merge_commit_sha"] = "something"
+                            pull_request = client.pull_requests(url).first
+                            assert pull_request.mergeable?
+                        end
+
                         it "returns the mergeable status" do
                             pull_request = client.pull_requests(url).first
                             assert pull_request.mergeable?

--- a/test/autoproj/daemon/git_api/services/test_github.rb
+++ b/test/autoproj/daemon/git_api/services/test_github.rb
@@ -53,6 +53,20 @@ module Autoproj
                     end
                 end
 
+                describe "creation of the service" do
+                    it "passes the authentication arguments to octokit" do
+                        flexmock(Octokit::Client)
+                            .should_receive(:new)
+                            .with(hsh({ access_token: "apikey" })).once.pass_thru
+                        flexmock(Octokit::Client)
+                            .should_receive(:new)
+                            .with(hsh({ access_token: "apikey" })).once.pass_thru
+
+                        client = Client.new(ws)
+                        client.service_for_host("github.com")
+                    end
+                end
+
                 describe "mock API tests" do
                     attr_reader :octomock, :url, :branch_model, :pr_model
 

--- a/test/autoproj/daemon/git_api/test_client.rb
+++ b/test/autoproj/daemon/git_api/test_client.rb
@@ -17,11 +17,12 @@ module Autoproj
 
                 # Dummy service
                 class Dummy < Service
-                    attr_reader :access_token
+                    attr_reader :access_token, :some_extra
 
-                    def initialize(**options)
-                        super
+                    def initialize(some_extra: nil, **options)
+                        super(**options)
                         @access_token = options[:access_token]
+                        @some_extra = some_extra
                     end
 
                     def default_endpoint
@@ -123,7 +124,8 @@ module Autoproj
                 describe "#initialize" do
                     it "passes options to services instances" do
                         ws.config.daemon_set_service(
-                            "dummy.com", "apikey", "https://dummy", "dummy"
+                            "dummy.com", "apikey", "https://dummy", "dummy",
+                            some_extra: "option"
                         )
                         @client = Client.new(ws)
 
@@ -132,6 +134,7 @@ module Autoproj
                         assert_equal "dummy.com", service.host
                         assert_equal "apikey", service.access_token
                         assert_equal "https://dummy", service.api_endpoint
+                        assert_equal "option", service.some_extra
 
                         assert client.supports?("git@dummy.com:foo/bar")
                         assert client.services.key?("dummy.com")

--- a/test/autoproj/daemon/git_api/test_pull_request.rb
+++ b/test/autoproj/daemon/git_api/test_pull_request.rb
@@ -11,11 +11,35 @@ module Autoproj
         module GitAPI
             describe PullRequest do
                 describe "#recursive_dependencies" do
-                    it "handles cycles in the pull requests dependencies" do
-                        pr0 = PullRequest.new("", {})
-                        pr1 = PullRequest.new("", {})
-                        pr2 = PullRequest.new("", {})
+                    attr_reader :pr0, :pr1, :pr2
 
+                    before do
+                        @pr0 = PullRequest.new("0", {})
+                        @pr0.dependencies = []
+                        @pr1 = PullRequest.new("1", {})
+                        @pr1.dependencies = []
+                        @pr2 = PullRequest.new("2", {})
+                        @pr2.dependencies = []
+                    end
+
+                    it "returns the direct dependencies" do
+                        pr0.dependencies = [pr1, pr2]
+
+                        assert_equal Set[pr1, pr2], pr0.recursive_dependencies.to_set
+                        assert_equal Set[], pr1.recursive_dependencies.to_set
+                        assert_equal Set[], pr2.recursive_dependencies.to_set
+                    end
+
+                    it "returns the dependencies of dependencies" do
+                        pr0.dependencies = [pr1]
+                        pr1.dependencies = [pr2]
+
+                        assert_equal Set[pr1, pr2], pr0.recursive_dependencies.to_set
+                        assert_equal Set[pr2], pr1.recursive_dependencies.to_set
+                        assert_equal Set[], pr2.recursive_dependencies.to_set
+                    end
+
+                    it "handles cycles in the pull requests dependencies" do
                         pr0.dependencies = [pr1, pr2]
                         pr1.dependencies = [pr2]
                         pr2.dependencies = [pr0]

--- a/test/autoproj/daemon/git_api/test_pull_request.rb
+++ b/test/autoproj/daemon/git_api/test_pull_request.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "autoproj/daemon/git_api/client"
+require "test_helper"
+
+# Autoproj's main module
+module Autoproj
+    # Daemon main module
+    module Daemon
+        # :nodoc:
+        module GitAPI
+            describe PullRequest do
+                describe "#recursive_dependencies" do
+                    it "handles cycles in the pull requests dependencies" do
+                        pr0 = PullRequest.new("", {})
+                        pr1 = PullRequest.new("", {})
+                        pr2 = PullRequest.new("", {})
+
+                        pr0.dependencies = [pr1, pr2]
+                        pr1.dependencies = [pr2]
+                        pr2.dependencies = [pr0]
+
+                        assert_equal Set[pr1, pr2], pr0.recursive_dependencies.to_set
+                        assert_equal Set[pr0, pr2], pr1.recursive_dependencies.to_set
+                        assert_equal Set[pr0, pr1], pr2.recursive_dependencies.to_set
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "autoproj/daemon/buildbot"
-require "timecop"
 
 # Autoproj's main module
 module Autoproj

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require "yaml"
 require "octokit"
 require "open3"
 require "rubygems/package"
+require "timecop"
 
 module Autoproj
     module Daemon
@@ -51,6 +52,11 @@ module Autoproj
             def setup
                 super
                 @storage = GithubStorage.new
+            end
+
+            def teardown
+                Timecop.return
+                super
             end
 
             def autoproj_daemon_create_ws(**vcs)


### PR DESCRIPTION
After the refactoring for GitLab support, GitHub's support to use merge branches was broken. The issue was that the GH API does not return the "mergeable" flag in its PR list endpoint, only on the per-pull request GET endpoint.

I started fixing this by looking for the merge_commit_sha field that does exist in the listing endpoint. Turns out that this is not enough, as GH does not re-compute the merge commit in some cases. We have to actually hit the pull request GET endpoint to force the update.

At that point, ended up having issues with faraday-cache. The GET endpoint was being cached, which meant that we were not triggering the merge commit computation and were waiting forever for it to be updated. I disabled caching for this endpoint - using a separate octokit client for it. Originally, I disabled for the whole daemon but that would be triggering rate limits regularly.