### PR TITLE
Send names of packages that triggered a build to buildbot

### DIFF
--- a/lib/autoproj/daemon/buildbot.rb
+++ b/lib/autoproj/daemon/buildbot.rb
@@ -47,13 +47,15 @@ module Autoproj
             # Publish a change indicating that a pull request was modified
             #
             # @param [GitAPI::PullRequest] pull_request
+            # @param [Array<String>] package_names
             # @return [Boolean] true if the posting was successful, false otherwise
-            def post_pull_request_changes(pull_request)
+            def post_pull_request_changes(pull_request, package_names: [])
                 branch_name = GitPoller.branch_name_by_pull_request(
                     @project, pull_request
                 )
 
                 post_change(
+                    package_names: package_names,
                     author: pull_request.author,
                     branch: branch_name,
                     source_branch: pull_request.head_branch,
@@ -70,11 +72,12 @@ module Autoproj
 
             # Publish changes that happened to a mainline branch
             #
-            # @param [PackageRepository] _package
+            # @param [PackageRepository] package
             # @param [GitAPI::Branch] remote_branch
             # @return [Boolean]
-            def post_mainline_changes(_package, remote_branch, buildconf_branch: "master")
+            def post_mainline_changes(package, remote_branch, buildconf_branch: "master")
                 post_change(
+                    package_names: [package.package],
                     # Codebase is a single codebase - i.e. single repo, but
                     # tracked across forks
                     author: remote_branch.commit_author,
@@ -92,6 +95,7 @@ module Autoproj
 
             # @return [Boolean]
             def post_change(
+                package_names: [],
                 author: "",
                 branch: "master",
                 source_branch: "master",
@@ -110,6 +114,7 @@ module Autoproj
                 request = Net::HTTP::Post.new(uri.request_uri)
 
                 properties = {
+                    package_names: package_names,
                     source_branch: source_branch,
                     source_project_id: source_project_id
                 }.compact

--- a/lib/autoproj/daemon/git_poller.rb
+++ b/lib/autoproj/daemon/git_poller.rb
@@ -385,7 +385,8 @@ module Autoproj
             # @return [void]
             def trigger_build(branch)
                 pr = pull_request_by_branch(branch)
-                bb.post_pull_request_changes(pr)
+                package_names = packages_affected_by_pull_request(pr).map(&:package)
+                bb.post_pull_request_changes(pr, package_names: package_names)
             end
 
             # @param [Array<GitAPI::Branch>] branches
@@ -398,7 +399,8 @@ module Autoproj
 
                     Autoproj.message "Updating #{pr.git_url.full_path}##{pr.number}"
                     commit_and_push_overrides(branch.branch_name, overrides)
-                    bb.post_pull_request_changes(pr)
+                    package_names = packages_affected_by_pull_request(pr).map(&:package)
+                    bb.post_pull_request_changes(pr, package_names: package_names)
                     cache.add(pr)
                 end
             end

--- a/test/autoproj/daemon/test_buildbot.rb
+++ b/test/autoproj/daemon/test_buildbot.rb
@@ -50,6 +50,7 @@ module Autoproj
                         "revlink" => "",
                         "when_timestamp" => Time.now.to_s,
                         "properties" => {
+                            package_names: ["foobar"],
                             source_branch: "feature",
                             source_project_id: 1
                         }.to_json
@@ -62,7 +63,11 @@ module Autoproj
                             response
                         end
 
-                    assert bb.post_change(source_branch: "feature", source_project_id: 1)
+                    assert bb.post_change(
+                        package_names: ["foobar"],
+                        source_branch: "feature",
+                        source_project_id: 1
+                    )
                 end
                 it "returns false if command fails" do
                     ws.config.daemon_buildbot_host = "bb-master"
@@ -94,6 +99,7 @@ module Autoproj
                 it "adds buildbot force build paramaters" do
                     now = Time.now
                     flexmock(bb).should_receive(:post_change).with(
+                        package_names: ["foobar"],
                         author: "author",
                         branch: "autoproj/wetpaint/github.com/"\
                                 "tidewise/drivers-gps_ublox/pulls/22",
@@ -120,13 +126,14 @@ module Autoproj
                         updated_at: now
                     )
 
-                    bb.post_pull_request_changes(pr)
+                    bb.post_pull_request_changes(pr, package_names: ["foobar"])
                 end
             end
             describe "#post_mainline_changes" do
                 it "adds buildbot force build paramaters" do
                     now = Time.now
                     flexmock(bb).should_receive(:post_change).with(
+                        package_names: ["foobar"],
                         author: "g-arjones",
                         branch: "main",
                         source_branch: "devel",
@@ -147,7 +154,9 @@ module Autoproj
                         commit_date: now
                     )
 
-                    bb.post_mainline_changes(flexmock, branch, buildconf_branch: "main")
+                    package = flexmock
+                    package.should_receive(:package).and_return("foobar")
+                    bb.post_mainline_changes(package, branch, buildconf_branch: "main")
                 end
             end
         end

--- a/test/autoproj/daemon/test_git_poller.rb
+++ b/test/autoproj/daemon/test_git_poller.rb
@@ -61,10 +61,10 @@ module Autoproj
                     .ordered
             end
 
-            def expect_pull_request_build(pull_request)
+            def expect_pull_request_build(pull_request, package_names: [])
                 flexmock(@poller.bb)
                     .should_receive(:post_pull_request_changes)
-                    .with(pull_request)
+                    .with(pull_request, package_names: package_names)
                     .once
                     .ordered
             end
@@ -692,7 +692,9 @@ module Autoproj
                     flexmock(@poller).should_receive(:commit_and_push_overrides)
                                      .with(branch_name, expected_overrides).once
 
-                    expect_pull_request_build(pr)
+                    expect_pull_request_build(
+                        pr, package_names: ["drivers/iodrivers_base"]
+                    )
                     @poller.trigger_build_if_branch_changed([branch])
                 end
                 it "triggers if PR head sha changed" do
@@ -736,7 +738,9 @@ module Autoproj
                     branch_name = "autoproj/myproject/github.com/"\
                                   "rock-core/drivers-iodrivers_base/pulls/12"
 
-                    expect_pull_request_build(pr)
+                    expect_pull_request_build(
+                        pr, package_names: ["drivers/iodrivers_base"]
+                    )
                     flexmock(@poller).should_receive(:commit_and_push_overrides)
                                      .with(branch_name, overrides).once
 
@@ -784,7 +788,9 @@ module Autoproj
                     branch_name = "autoproj/myproject/github.com/"\
                                   "rock-core/drivers-iodrivers_base/pulls/12"
 
-                    expect_pull_request_build(pr)
+                    expect_pull_request_build(
+                        pr, package_names: ["drivers/iodrivers_base"]
+                    )
                     flexmock(@poller).should_receive(:commit_and_push_overrides)
                                      .with(branch_name, overrides).once
 
@@ -833,7 +839,9 @@ module Autoproj
                     branch_name = "autoproj/myproject/github.com/"\
                                   "rock-core/drivers-iodrivers_base/pulls/12"
 
-                    expect_pull_request_build(pr)
+                    expect_pull_request_build(
+                        pr, package_names: ["drivers/iodrivers_base"]
+                    )
                     flexmock(@poller).should_receive(:commit_and_push_overrides)
                                      .with(branch_name, overrides).once
 


### PR DESCRIPTION
The goal is to have them available as a build property on the buildbot master for build reports.